### PR TITLE
feat: initialize package scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+.env.local
+.env.*.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
 # vercel-deploy-scripts
+
+Shared deployment and security tooling for Firebase + Next.js projects hosted on Vercel. Consumed as a git dependency — no registry needed.
+
+## Installation
+
+```json
+{
+  "dependencies": {
+    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v1.0.0"
+  }
+}
+```
+
+Then run `npm install` (or `pnpm install` / `yarn`).
+
+## What's included
+
+| Script               | Purpose                                                                    |
+| -------------------- | -------------------------------------------------------------------------- |
+| `generate-local-env` | Pulls `.env.local` from your Vercel preview environment                    |
+| `secrets-check`      | Pre-commit gitleaks wrapper; skips gracefully if gitleaks is not installed |
+
+A base `.gitleaks.toml` is also provided for consuming repos to extend, and a reusable GitHub Actions workflow for secret scanning in CI.
+
+## Scripts
+
+### `generate-local-env`
+
+Requires the [Vercel CLI](https://vercel.com/docs/cli) to be installed and authenticated. Wire it into your `package.json`:
+
+```json
+{
+  "scripts": {
+    "env:pull": "generate-local-env"
+  }
+}
+```
+
+### `secrets-check`
+
+A pre-commit gitleaks wrapper. If gitleaks is not installed it warns and exits 0 so developers are never blocked; the CI workflow enforces the scan unconditionally.
+
+Wire it into your Husky pre-commit hook (`.husky/pre-commit`):
+
+```sh
+#!/usr/bin/env sh
+npx lint-staged
+secrets-check
+```
+
+## Gitleaks config
+
+Extend the base config in your repo's `.gitleaks.toml`:
+
+```toml
+[extend]
+path = "node_modules/vercel-deploy-scripts/.gitleaks.toml"
+
+# Add project-specific rules or allowlist entries below
+```
+
+## CI secret scan
+
+Reference the reusable workflow from your own workflow file:
+
+```yaml
+jobs:
+  secret-scan:
+    uses: rmartz/vercel-deploy-scripts/.github/workflows/secret-scan.yml@v1
+```
+
+## Terraform environment variable management
+
+See `templates/terraform/` for Terraform configuration that manages Vercel environment variables from `deployment/{env}.yml` YAML files. Copy the templates into your repo and follow the README in that directory.
+
+## Peer requirements
+
+- Node.js ≥ 18
+- [Vercel CLI](https://vercel.com/docs/cli) (for `generate-local-env`)
+- [gitleaks](https://github.com/gitleaks/gitleaks) (for `secrets-check`; optional locally, enforced in CI)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vercel-deploy-scripts",
+  "version": "0.0.0",
+  "description": "Shared deployment and security tooling for Firebase + Next.js projects hosted on Vercel",
+  "license": "MIT",
+  "bin": {
+    "generate-local-env": "./scripts/generate-local-env.sh",
+    "secrets-check": "./scripts/secrets-check.sh"
+  },
+  "files": [
+    "scripts/",
+    ".gitleaks.toml",
+    "templates/"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/generate-local-env.sh
+++ b/scripts/generate-local-env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "generate-local-env: not yet implemented" >&2
+exit 1

--- a/scripts/secrets-check.sh
+++ b/scripts/secrets-check.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "secrets-check: not yet implemented" >&2
+exit 1


### PR DESCRIPTION
Establishes the foundational structure for `vercel-deploy-scripts` as a git-installable npm package.

- `package.json` with `bin` entries for `generate-local-env` and `secrets-check`, `files` allowlist, and no runtime dependencies
- Stub scripts in `scripts/` (executable, `set -euo pipefail`) so the `bin` entries resolve immediately; implementation follows in #2 and #3
- `.gitignore` for Node packages
- Expanded `README.md` covering installation, all planned scripts, gitleaks config extension pattern, CI workflow reference, and Terraform templates

Closes #1

---
*Created by Claude Sonnet 4.6*