### PR TITLE
feat: implement generate-local-env script

### DIFF
--- a/scripts/generate-local-env.sh
+++ b/scripts/generate-local-env.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "generate-local-env: not yet implemented" >&2
-exit 1
+if ! command -v vercel &>/dev/null; then
+  echo "generate-local-env: vercel CLI not found. Install it with: npm i -g vercel" >&2
+  exit 1
+fi
+
+if ! vercel whoami &>/dev/null; then
+  echo "generate-local-env: not authenticated. Run: vercel login" >&2
+  exit 1
+fi
+
+vercel env pull .env.local --environment=preview


### PR DESCRIPTION
Implements `scripts/generate-local-env.sh`, which pulls `.env.local` from the linked Vercel project's preview environment.

The script checks for the Vercel CLI and an active login before running `vercel env pull`, so consumers get a clear, actionable error instead of a cryptic failure. Project configuration is expected to live in `.vercel/project.json` (set up separately via `vercel link`), keeping this script fully self-contained and project-agnostic.

Closes #2

---
*Created by Claude Sonnet 4.6*