### PR TITLE
feat: implement secrets-check gitleaks wrapper

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,38 @@
+[extend]
+useDefault = true
+
+[allowlist]
+regexes = [
+  '''YOUR_[A-Z0-9_]*''',
+  '''PLACEHOLDER_[A-Z0-9_]*''',
+  '''<[^>]+>''',
+  '''(?i)^example$''',
+  '''(?i)^changeme$''',
+]
+
+[[rules]]
+id = "firebase-private-key"
+description = "Firebase service account private key"
+regex = '''-----BEGIN PRIVATE KEY-----'''
+tags = ["firebase", "key"]
+
+[rules.allowlist]
+regexes = ['''YOUR_PRIVATE_KEY''', '''<private_key>''']
+
+[[rules]]
+id = "firebase-service-account-json"
+description = "Firebase service account JSON blob"
+regex = '''"type"\s*:\s*"service_account"'''
+tags = ["firebase", "credentials"]
+
+[rules.allowlist]
+regexes = ['''YOUR_SERVICE_ACCOUNT''', '''<service_account>''']
+
+[[rules]]
+id = "vercel-api-token"
+description = "Vercel API token"
+regex = '''(?:vercel_[a-zA-Z0-9]{24,}|(?:VERCEL_TOKEN|VERCEL_API_TOKEN)\s*=\s*[a-zA-Z0-9_\-]{20,})'''
+tags = ["vercel", "token"]
+
+[rules.allowlist]
+regexes = ['''vercel_YOUR_.*''', '''vercel_PLACEHOLDER_.*''', '''<vercel[_-]token>''']

--- a/scripts/secrets-check.sh
+++ b/scripts/secrets-check.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "secrets-check: not yet implemented" >&2
-exit 1
+if command -v realpath > /dev/null 2>&1; then
+  SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+
+DEFAULT_CONFIG="$(cd "$SCRIPT_DIR/.." && pwd)/.gitleaks.toml"
+CONFIG="$DEFAULT_CONFIG"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)
+      CONFIG="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if ! command -v gitleaks > /dev/null 2>&1; then
+  echo "secrets-check: gitleaks not installed, skipping secret scan" >&2
+  exit 0
+fi
+
+exec gitleaks protect --staged --config "$CONFIG"


### PR DESCRIPTION
Implements the `secrets-check.sh` pre-commit hook that wraps gitleaks. When gitleaks is not installed the script prints a warning to stderr and exits 0 (non-blocking for local dev; CI enforces separately). When gitleaks is present it runs `gitleaks protect --staged` with the bundled `.gitleaks.toml` config.

Config path is resolved via `realpath` so the script works correctly whether invoked directly or through a `node_modules/.bin` symlink. An optional `--config <path>` flag allows overriding the default config.

Closes #3

---
*Created by Claude Sonnet 4.6*