### PR TITLE
feat: provide Terraform config templates for Vercel env var management

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,30 @@ jobs:
 
 ## Terraform environment variable management
 
-See `templates/terraform/` for Terraform configuration that manages Vercel environment variables from `deployment/{env}.yml` YAML files. Copy the templates into your repo and follow the README in that directory.
+`templates/terraform/` contains a ready-to-use Terraform configuration that manages Vercel environment variables from `deployment/environments.yml` and per-environment `deployment/{env}.yml` YAML files (the same layout used by `firebase-nextjs-template`). It creates `vercel_project_environment_variable` resources for every non-empty value and maps `staging → preview` for the Vercel target.
+
+`templates/workflows/terraform-plan.yml` is a companion GitHub Actions workflow that runs `terraform validate` on every PR and `terraform plan` when secrets are present.
+
+### Initializing a consuming repo
+
+Run the `init-terraform` script once in the root of the consuming repo after installing this package:
+
+```sh
+npx init-terraform
+```
+
+This copies:
+
+- `node_modules/vercel-deploy-scripts/templates/terraform/` → `terraform/`
+- `node_modules/vercel-deploy-scripts/templates/workflows/terraform-plan.yml` → `.github/workflows/terraform-plan.yml`
+
+The script is idempotent — it will warn and skip any destination that already exists.
+
+After running it:
+
+1. Copy `terraform/terraform.tfvars.example` → `terraform/terraform.tfvars` and fill in `vercel_project_id` (and optionally `vercel_team_id`).
+2. Add `VERCEL_PROJECT_ID`, `VERCEL_TEAM_ID` (if applicable), and `VERCEL_API_TOKEN` to your GitHub Actions secrets.
+3. Run `cd terraform && terraform init`.
 
 ## Peer requirements
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ jobs:
 
 `templates/workflows/terraform-plan.yml` is a companion GitHub Actions workflow that runs `terraform validate` on every PR and `terraform plan` when secrets are present.
 
+### Prerequisites
+
+- [Terraform CLI](https://developer.hashicorp.com/terraform/install) ≥ 1.0 must be installed locally to run `terraform init`, `validate`, and `plan`.
+- The [Vercel Terraform provider](https://registry.terraform.io/providers/vercel/vercel/latest) (`vercel/vercel`) is declared in `main.tf` and is downloaded automatically by `terraform init` — no manual installation needed.
+
 ### Initializing a consuming repo
 
 Run the `init-terraform` script once in the root of the consuming repo after installing this package:
@@ -96,6 +101,39 @@ After running it:
 1. Copy `terraform/terraform.tfvars.example` → `terraform/terraform.tfvars` and fill in `vercel_project_id` (and optionally `vercel_team_id`).
 2. Add `VERCEL_PROJECT_ID`, `VERCEL_TEAM_ID` (if applicable), and `VERCEL_API_TOKEN` to your GitHub Actions secrets.
 3. Run `cd terraform && terraform init`.
+
+### State management
+
+By default Terraform stores state locally in `terraform/terraform.tfstate`. This is fine for solo projects but is not suitable for teams. The copied `terraform/main.tf` includes commented-out backend blocks you can uncomment to switch to a remote backend:
+
+```hcl
+# Terraform Cloud / HCP Terraform
+# terraform {
+#   cloud {
+#     organization = "your-org"
+#     workspaces {
+#       name = "your-workspace"
+#     }
+#   }
+# }
+
+# Google Cloud Storage
+# terraform {
+#   backend "gcs" {
+#     bucket = "your-tfstate-bucket"
+#     prefix = "terraform/state"
+#   }
+# }
+```
+
+After uncommenting a backend block, run `terraform init -migrate-state` to move existing local state into the remote backend.
+
+### CI workflow wiring
+
+`init-terraform` copies `terraform-plan.yml` verbatim to `.github/workflows/terraform-plan.yml` in the consuming repo. No additional wiring is required — the workflow is self-contained and triggers on pull requests to the default branch.
+
+- On every PR: `terraform validate` runs unconditionally to catch syntax errors.
+- `terraform plan` runs only when the `VERCEL_API_TOKEN` secret is present, so forks and external contributors are not blocked.
 
 ## Peer requirements
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "bin": {
     "generate-local-env": "./scripts/generate-local-env.sh",
+    "init-terraform": "./scripts/init-terraform.sh",
     "secrets-check": "./scripts/secrets-check.sh"
   },
   "files": [

--- a/scripts/init-terraform.sh
+++ b/scripts/init-terraform.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TEMPLATES_DIR="${PACKAGE_ROOT}/templates"
+
+DEST_TERRAFORM="terraform"
+DEST_WORKFLOW=".github/workflows/terraform-plan.yml"
+
+skipped=0
+
+if [[ -d "${DEST_TERRAFORM}" ]]; then
+  echo "WARNING: '${DEST_TERRAFORM}/' already exists — skipping copy. Remove it to reinitialize." >&2
+  skipped=1
+else
+  cp -r "${TEMPLATES_DIR}/terraform" "${DEST_TERRAFORM}"
+  echo "Copied terraform templates → ${DEST_TERRAFORM}/"
+fi
+
+if [[ -f "${DEST_WORKFLOW}" ]]; then
+  echo "WARNING: '${DEST_WORKFLOW}' already exists — skipping copy. Remove it to reinitialize." >&2
+  skipped=1
+else
+  mkdir -p "$(dirname "${DEST_WORKFLOW}")"
+  cp "${TEMPLATES_DIR}/workflows/terraform-plan.yml" "${DEST_WORKFLOW}"
+  echo "Copied workflow template → ${DEST_WORKFLOW}"
+fi
+
+if [[ "${skipped}" -eq 0 ]]; then
+  echo ""
+  echo "Next steps:"
+  echo "  1. Copy terraform/terraform.tfvars.example → terraform/terraform.tfvars and fill in your values"
+  echo "  2. Add VERCEL_PROJECT_ID, VERCEL_TEAM_ID (if applicable), and VERCEL_API_TOKEN to GitHub Actions secrets"
+  echo "  3. Run: cd terraform && terraform init"
+fi

--- a/templates/terraform/.gitignore
+++ b/templates/terraform/.gitignore
@@ -1,0 +1,8 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+*.tfstate
+*.tfstate.backup
+terraform.tfvars
+crash.log

--- a/templates/terraform/main.tf
+++ b/templates/terraform/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 1.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+    yamldecode = {}
+  }
+}
+
+provider "vercel" {
+  api_token = var.vercel_api_token
+  team      = var.vercel_team_id
+}
+
+locals {
+  environments = yamldecode(file("${path.root}/../deployment/environments.yml"))
+
+  target_map = {
+    production = "production"
+    staging    = "preview"
+    preview    = "preview"
+  }
+
+  env_vars = merge([
+    for env in local.environments.active : {
+      for k, v in yamldecode(file("${path.root}/../deployment/${env}.yml")) :
+      "${env}:${k}" => {
+        key    = k
+        value  = v
+        target = local.target_map[env]
+      }
+      if v != null && v != ""
+    }
+  ]...)
+}
+
+resource "vercel_project_environment_variable" "vars" {
+  for_each = local.env_vars
+
+  project_id = var.vercel_project_id
+  team_id    = var.vercel_team_id
+  key        = each.value.key
+  value      = each.value.value
+  target     = [each.value.target]
+}

--- a/templates/terraform/main.tf
+++ b/templates/terraform/main.tf
@@ -4,12 +4,24 @@ terraform {
       source  = "vercel/vercel"
       version = "~> 1.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = "~> 2.0"
-    }
-    yamldecode = {}
   }
+
+  # Uncomment one of the following backend blocks to store state remotely.
+  # After uncommenting, run: terraform init -migrate-state
+
+  # Terraform Cloud / HCP Terraform
+  # cloud {
+  #   organization = "your-org"
+  #   workspaces {
+  #     name = "your-workspace"
+  #   }
+  # }
+
+  # Google Cloud Storage
+  # backend "gcs" {
+  #   bucket = "your-tfstate-bucket"
+  #   prefix = "terraform/state"
+  # }
 }
 
 provider "vercel" {

--- a/templates/terraform/terraform.tfvars.example
+++ b/templates/terraform/terraform.tfvars.example
@@ -1,0 +1,2 @@
+vercel_project_id = "prj_xxxxxxxxxxxxxxxxxxxx"
+# vercel_team_id  = "team_xxxxxxxxxxxxxxxxxxxx"  # uncomment for team accounts

--- a/templates/terraform/variables.tf
+++ b/templates/terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "vercel_project_id" {
+  type        = string
+  description = "Vercel project ID (found in Project Settings → General)"
+}
+
+variable "vercel_team_id" {
+  type        = string
+  description = "Vercel team ID; null for personal accounts"
+  default     = null
+}
+
+variable "vercel_api_token" {
+  type        = string
+  description = "Vercel API token — set via TF_VAR_vercel_api_token or VERCEL_API_TOKEN env var"
+  sensitive   = true
+}

--- a/templates/workflows/terraform-plan.yml
+++ b/templates/workflows/terraform-plan.yml
@@ -1,0 +1,31 @@
+name: Terraform Plan
+on:
+  pull_request:
+    paths:
+      - "deployment/**"
+      - "terraform/**"
+  push:
+    branches: [main]
+    paths:
+      - "deployment/**"
+      - "terraform/**"
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform init -backend=false
+      - run: terraform validate
+      - name: Terraform Plan
+        if: ${{ env.VERCEL_API_TOKEN != '' }}
+        run: terraform plan
+        env:
+          TF_VAR_vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID }}
+          TF_VAR_vercel_team_id: ${{ secrets.VERCEL_TEAM_ID }}
+          TF_VAR_vercel_api_token: ${{ secrets.VERCEL_API_TOKEN }}
+          VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}


### PR DESCRIPTION
Provides reusable Terraform configuration templates so every `firebase-nextjs-template`-derived repo can manage Vercel environment variables without duplicating files.

## What's included

- `templates/terraform/` — `main.tf`, `variables.tf`, `terraform.tfvars.example`, `.gitignore`; reads `deployment/environments.yml` and per-env YAML files, creates `vercel_project_environment_variable` resources, maps `staging → preview`
- `templates/workflows/terraform-plan.yml` — GitHub Actions workflow running `terraform validate` on PRs and `terraform plan` when secrets are present
- `scripts/init-terraform.sh` — idempotent setup helper that copies both template sets into a consuming repo; exposed as the `init-terraform` bin entry

Consuming repos run `npx init-terraform` once, fill in `terraform.tfvars`, add GitHub secrets, and run `terraform init`.

Closes #7

---
*Created by Claude Sonnet 4.6*