### PR TITLE
feat: add reusable secret-scan CI workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,20 @@
+name: Secret Scan
+on:
+  workflow_call:
+    inputs:
+      config-path:
+        description: "Path to a custom gitleaks config file"
+        required: false
+        type: string
+        default: ""
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: ${{ inputs.config-path }}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ jobs:
     uses: rmartz/vercel-deploy-scripts/.github/workflows/secret-scan.yml@v1
 ```
 
+The workflow checks out your repo with full history and runs gitleaks via `gitleaks/gitleaks-action@v2`. If a `.gitleaks.toml` exists in your repo root, it is picked up automatically.
+
+To supply a custom config path, pass the optional `config-path` input:
+
+```yaml
+jobs:
+  secret-scan:
+    uses: rmartz/vercel-deploy-scripts/.github/workflows/secret-scan.yml@v1
+    with:
+      config-path: .github/gitleaks.toml
+```
+
 ## Terraform environment variable management
 
 See `templates/terraform/` for Terraform configuration that manages Vercel environment variables from `deployment/{env}.yml` YAML files. Copy the templates into your repo and follow the README in that directory.


### PR DESCRIPTION
Adds `.github/workflows/secret-scan.yml` as a `workflow_call`-triggered reusable workflow so consuming repos can run gitleaks secret scanning with a two-line `uses:` snippet, without copying any job logic.

The workflow checks out the calling repo with full history and delegates to `gitleaks/gitleaks-action@v2`, which handles download, caching, and execution. An optional `config-path` input lets callers override the config file path via the `GITLEAKS_CONFIG` env var; omitting it causes the action to pick up any `.gitleaks.toml` in the repo root automatically.

README's "CI secret scan" section is updated with the full `uses:` snippet and documents the optional input.

Closes #6

---
*Created by Claude Sonnet 4.6*