### PR TITLE
fix: bump Node to 22 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       - run: npx semantic-release
         env:


### PR DESCRIPTION
semantic-release now requires Node ^22.14.0 or >= 24.10.0. The release workflow was pinned to Node 20, causing the workflow to fail immediately on startup.

Changes `node-version: 20` → `node-version: 22` in `.github/workflows/release.yml`.

---
*Created by Claude Sonnet 4.6*