### PR TITLE
fix: add install-deps input to secret-scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -26,7 +26,7 @@ jobs:
       - if: ${{ inputs.install-deps }}
         uses: actions/setup-node@v4
         with:
-          node-version-file: .node-version
+          node-version: "lts/*"
           cache: pnpm
       - if: ${{ inputs.install-deps }}
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -7,6 +7,11 @@ on:
         required: false
         type: string
         default: ""
+      install-deps:
+        description: "Run pnpm install before scanning (required when gitleaks config extends a file inside node_modules/)"
+        required: false
+        type: boolean
+        default: false
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
@@ -14,6 +19,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - if: ${{ inputs.install-deps }}
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - if: ${{ inputs.install-deps }}
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - if: ${{ inputs.install-deps }}
+        run: pnpm install --frozen-lockfile
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,23 @@
 
 # [1.1.0](https://github.com/rmartz/vercel-deploy-scripts/compare/v1.0.0...v1.1.0) (2026-04-28)
 
-
 ### Features
 
-* add reusable secret-scan CI workflow ([#15](https://github.com/rmartz/vercel-deploy-scripts/issues/15)) ([196a3cf](https://github.com/rmartz/vercel-deploy-scripts/commit/196a3cf4e137ee775e727497476e8e7cf571a829)), closes [#6](https://github.com/rmartz/vercel-deploy-scripts/issues/6)
+- add reusable secret-scan CI workflow ([#15](https://github.com/rmartz/vercel-deploy-scripts/issues/15)) ([196a3cf](https://github.com/rmartz/vercel-deploy-scripts/commit/196a3cf4e137ee775e727497476e8e7cf571a829)), closes [#6](https://github.com/rmartz/vercel-deploy-scripts/issues/6)
 
 # 1.0.0 (2026-04-28)
 
-
 ### Bug Fixes
 
-* bump Node to 22 in release workflow ([#16](https://github.com/rmartz/vercel-deploy-scripts/issues/16)) ([a47ae8f](https://github.com/rmartz/vercel-deploy-scripts/commit/a47ae8f45a78ebed5b5e7d98f7dc6b307aeae4cc))
-
+- bump Node to 22 in release workflow ([#16](https://github.com/rmartz/vercel-deploy-scripts/issues/16)) ([a47ae8f](https://github.com/rmartz/vercel-deploy-scripts/commit/a47ae8f45a78ebed5b5e7d98f7dc6b307aeae4cc))
 
 ### Features
 
-* add base gitleaks config ([#12](https://github.com/rmartz/vercel-deploy-scripts/issues/12)) ([17a39ad](https://github.com/rmartz/vercel-deploy-scripts/commit/17a39ad6a5a97cf27e2b8a9d2b8bbec5484b4bd9)), closes [#4](https://github.com/rmartz/vercel-deploy-scripts/issues/4)
-* implement generate-local-env script ([#10](https://github.com/rmartz/vercel-deploy-scripts/issues/10)) ([241e1ff](https://github.com/rmartz/vercel-deploy-scripts/commit/241e1ff56aada3f1eeffd30e7e92f54d368c023e)), closes [#2](https://github.com/rmartz/vercel-deploy-scripts/issues/2)
-* implement secrets-check gitleaks wrapper ([#13](https://github.com/rmartz/vercel-deploy-scripts/issues/13)) ([57792f8](https://github.com/rmartz/vercel-deploy-scripts/commit/57792f867940378537c4663b3d0e845b594c2092)), closes [#3](https://github.com/rmartz/vercel-deploy-scripts/issues/3)
-* initialize package scaffold ([9ea507e](https://github.com/rmartz/vercel-deploy-scripts/commit/9ea507e4b6da7e029ef3daf5d10d496fa1daa0c6))
-* provide Terraform config templates for Vercel env var management ([9bd0326](https://github.com/rmartz/vercel-deploy-scripts/commit/9bd03266cfd66153d680023bf0a830e26082d21a)), closes [#7](https://github.com/rmartz/vercel-deploy-scripts/issues/7)
-* set up semantic-release for automated versioning ([#11](https://github.com/rmartz/vercel-deploy-scripts/issues/11)) ([ff72465](https://github.com/rmartz/vercel-deploy-scripts/commit/ff72465dbf348d41407f30a0fc2d7714cc630035)), closes [#5](https://github.com/rmartz/vercel-deploy-scripts/issues/5)
+- add base gitleaks config ([#12](https://github.com/rmartz/vercel-deploy-scripts/issues/12)) ([17a39ad](https://github.com/rmartz/vercel-deploy-scripts/commit/17a39ad6a5a97cf27e2b8a9d2b8bbec5484b4bd9)), closes [#4](https://github.com/rmartz/vercel-deploy-scripts/issues/4)
+- implement generate-local-env script ([#10](https://github.com/rmartz/vercel-deploy-scripts/issues/10)) ([241e1ff](https://github.com/rmartz/vercel-deploy-scripts/commit/241e1ff56aada3f1eeffd30e7e92f54d368c023e)), closes [#2](https://github.com/rmartz/vercel-deploy-scripts/issues/2)
+- implement secrets-check gitleaks wrapper ([#13](https://github.com/rmartz/vercel-deploy-scripts/issues/13)) ([57792f8](https://github.com/rmartz/vercel-deploy-scripts/commit/57792f867940378537c4663b3d0e845b594c2092)), closes [#3](https://github.com/rmartz/vercel-deploy-scripts/issues/3)
+- initialize package scaffold ([9ea507e](https://github.com/rmartz/vercel-deploy-scripts/commit/9ea507e4b6da7e029ef3daf5d10d496fa1daa0c6))
+- provide Terraform config templates for Vercel env var management ([9bd0326](https://github.com/rmartz/vercel-deploy-scripts/commit/9bd03266cfd66153d680023bf0a830e26082d21a)), closes [#7](https://github.com/rmartz/vercel-deploy-scripts/issues/7)
+- set up semantic-release for automated versioning ([#11](https://github.com/rmartz/vercel-deploy-scripts/issues/11)) ([ff72465](https://github.com/rmartz/vercel-deploy-scripts/commit/ff72465dbf348d41407f30a0fc2d7714cc630035)), closes [#5](https://github.com/rmartz/vercel-deploy-scripts/issues/5)
 
 # Changelog


### PR DESCRIPTION
When a caller's \`.gitleaks.toml\` extends a config via a path inside \`node_modules/\` (e.g. \`path = "node_modules/vercel-deploy-scripts/.gitleaks.toml"\`), the workflow fails because npm packages are never installed — only \`actions/checkout\` runs.

Adds an \`install-deps\` boolean input (default \`false\`). When \`true\`, the workflow installs pnpm, sets up Node using the repo's \`.node-version\` file, and runs \`pnpm install --frozen-lockfile\` before gitleaks executes. Callers opt in only when their config requires it, so the default path stays lightweight.

**Caller usage:**
\`\`\`yaml
uses: rmartz/vercel-deploy-scripts/.github/workflows/secret-scan.yml@main
with:
  config-path: .gitleaks.toml
  install-deps: true
\`\`\`

---
*Created by Claude Sonnet 4.6*