### PR TITLE
feat: add rotate-keys script for Firebase and Sentry key rotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "generate-local-env": "./scripts/generate-local-env.sh",
     "init-terraform": "./scripts/init-terraform.sh",
+    "rotate-keys": "./scripts/rotate-keys.sh",
     "secrets-check": "./scripts/secrets-check.sh"
   },
   "files": [

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -359,8 +359,28 @@ detect_firebase_pattern() {
   log "  GCP project     : $FIREBASE_GCP_PROJECT"
 }
 
+# Returns 0 if the given Vercel environment has a Firebase key configured,
+# checking the actual key variable (not FIREBASE_PRIVATE_KEY_ID, which may not
+# exist on projects set up before this script was used).
+has_firebase_key_for_env() {
+  local vercel_env="$1"
+  local all_envs="$2"
+  local key_name
+  if [[ "${FIREBASE_KEY_PATTERN:-}" == "json" ]]; then
+    key_name="FIREBASE_SERVICE_ACCOUNT"
+  else
+    key_name="FIREBASE_PRIVATE_KEY"
+  fi
+  local record_id
+  record_id="$(echo "$all_envs" | jq -r \
+    --arg t "$vercel_env" \
+    --arg k "$key_name" \
+    'first(.envs[] | select(.key == $k and (.target | index($t) != null)) | .id) // empty')"
+  [[ -n "$record_id" ]]
+}
+
 # Finds the private_key_id currently stored for a given Vercel environment.
-# Returns empty string if not found.
+# Returns empty string if not found (e.g. FIREBASE_PRIVATE_KEY_ID not tracked).
 get_firebase_key_id_for_env() {
   local vercel_env="$1"
   local all_envs="$2"
@@ -464,18 +484,25 @@ rotate_firebase() {
   while IFS= read -r vercel_env; do
     [[ -z "$vercel_env" ]] && continue
 
-    # Read old key ID before creating the new one
-    local old_key_id
-    old_key_id="$(get_firebase_key_id_for_env "$vercel_env" "$all_envs")"
-
-    if [[ -z "$old_key_id" ]]; then
-      if [[ "$TARGET_ENV" == "all" ]]; then
+    # For "--env all": skip environments with no Firebase key. Check the actual
+    # key var, not FIREBASE_PRIVATE_KEY_ID — projects set up before this script
+    # may not have the ID var tracked yet, causing all envs to appear unconfigured.
+    if [[ "$TARGET_ENV" == "all" ]]; then
+      if ! has_firebase_key_for_env "$vercel_env" "$all_envs"; then
         log "  [$vercel_env] No existing key — skipping (use --env $vercel_env to explicitly add)"
         continue
       fi
-      log "  [$vercel_env] No existing key found — will add"
-    else
+    fi
+
+    # Read old key ID (best-effort: empty if FIREBASE_PRIVATE_KEY_ID not tracked).
+    # Absence here does not mean the env is unconfigured; the stray-key sweep
+    # handles cleanup even without the prior key ID.
+    local old_key_id
+    old_key_id="$(get_firebase_key_id_for_env "$vercel_env" "$all_envs")"
+    if [[ -n "$old_key_id" ]]; then
       log "  [$vercel_env] Current key ID: $old_key_id"
+    else
+      log "  [$vercel_env] No key ID tracked — old key will be swept after redeployment"
     fi
 
     # Determine which Firebase SA owns this Vercel environment. In a two-env
@@ -753,7 +780,8 @@ invalidate_firebase_keys() {
   # production uses one SA and preview/development use the staging SA) as well
   # as prod-only projects (single SA across all environments).
   local active_keys=""
-  local sa_pair_list=""  # "email:project" entries, space-separated, deduplicated
+  local sa_pair_list=""    # "email:project" entries, space-separated, deduplicated
+  local unsweepable_sas="" # SAs where ≥1 env has a key but no key ID tracked
 
   for check_env in production preview development; do
     local kid sa_info
@@ -770,6 +798,14 @@ invalidate_firebase_keys() {
       if ! echo "$sa_pair_list" | grep -qF "$pair"; then
         sa_pair_list="${sa_pair_list} ${pair}"
       fi
+      # If the env has a key but no tracked key ID, we can't safely determine
+      # all active keys for this SA — mark it unsweepable to avoid deleting
+      # active keys from environments that were set up before this script.
+      if [[ -z "$kid" ]]; then
+        if ! echo "$unsweepable_sas" | grep -qF "$pair"; then
+          unsweepable_sas="${unsweepable_sas} ${pair}"
+        fi
+      fi
     fi
   done
 
@@ -779,6 +815,17 @@ invalidate_firebase_keys() {
   for pair in $sa_pair_list; do
     local sa_email="${pair%%:*}"
     local gcp_project="${pair#*:}"
+
+    # Skip SAs where at least one environment has a key but no tracked key ID.
+    # Without the full active-key set we'd incorrectly delete keys still in use.
+    # Rotate all environments first (which sets FIREBASE_PRIVATE_KEY_ID), then
+    # re-run to perform the sweep.
+    if echo "$unsweepable_sas" | grep -qF "$pair"; then
+      warn "Skipping stray-key sweep for $sa_email — not all environments have FIREBASE_PRIVATE_KEY_ID tracked."
+      warn "  Rotate all environments first, then re-run to sweep old keys."
+      continue
+    fi
+
     log "  Sweeping SA: $sa_email"
 
     local user_keys

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -421,24 +421,31 @@ rotate_firebase() {
   detect_firebase_pattern "$all_envs"
   log "  Key pattern: ${FIREBASE_KEY_PATTERN}"
 
-  # Determine which environments to rotate and which old keys to record.
-  # For "all", we always rotate production/preview/development. If an env is
-  # missing the key, we add it with a fresh GCP key.
+  # Rotate each targeted environment. For "--env all", only environments that
+  # already have a Firebase key are rotated — we don't add keys to environments
+  # that aren't configured (e.g. a prod/staging project with no development key).
+  # When a specific env is given explicitly (e.g. "--env development"), we add
+  # the key even if it doesn't exist yet, since that's the explicit intent.
   local rotated_any=false
 
   while IFS= read -r vercel_env; do
     [[ -z "$vercel_env" ]] && continue
 
-    log "  [$vercel_env] Rotating..."
-
     # Read old key ID before creating the new one
     local old_key_id
     old_key_id="$(get_firebase_key_id_for_env "$vercel_env" "$all_envs")"
-    if [[ -n "$old_key_id" ]]; then
-      log "  [$vercel_env] Current key ID: $old_key_id"
-    else
+
+    if [[ -z "$old_key_id" ]]; then
+      if [[ "$TARGET_ENV" == "all" ]]; then
+        log "  [$vercel_env] No existing key — skipping (use --env $vercel_env to explicitly add)"
+        continue
+      fi
       log "  [$vercel_env] No existing key found — will add"
+    else
+      log "  [$vercel_env] Current key ID: $old_key_id"
     fi
+
+    log "  [$vercel_env] Rotating..."
 
     # Create a fresh GCP service account key for this specific environment
     local new_key_file="$TEMP_DIR/key-${vercel_env}.json"

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+# ─── Defaults ─────────────────────────────────────────────────────────────────
+
+TARGET_ENV="all"       # production | preview | staging | development | all
+INVALIDATE_KEYS=true
+
+VERCEL_API="https://api.vercel.com"
+SENTRY_URL="${SENTRY_URL:-https://sentry.io}"
+
+# ─── Globals ──────────────────────────────────────────────────────────────────
+
+VERCEL_PROJECT_ID="${VERCEL_PROJECT_ID:-}"
+VERCEL_TEAM_ID="${VERCEL_TEAM_ID:-}"
+
+HAS_FIREBASE=false
+HAS_SENTRY=false
+
+# Maps Vercel env name → old GCP key ID (populated during rotation, consumed
+# during invalidation). Format: "production:KEY_ID preview:KEY_ID ..."
+# Stored as parallel arrays for bash 3.2 compatibility.
+OLD_FIREBASE_ENVS=()
+OLD_FIREBASE_KEYS=()
+FIREBASE_SA_EMAIL=""
+FIREBASE_GCP_PROJECT=""
+
+OLD_SENTRY_KEY_ID=""
+SENTRY_ORG_SLUG=""
+SENTRY_PROJECT_SLUG=""
+
+DEPLOYMENT_IDS=()
+TEMP_DIR=""
+
+# ─── Cleanup ──────────────────────────────────────────────────────────────────
+
+cleanup() {
+  if [[ -n "${TEMP_DIR:-}" && -d "${TEMP_DIR:-}" ]]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+# ─── Usage ────────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $SCRIPT_NAME [OPTIONS]
+
+Rotate Firebase service account keys and Sentry DSN keys in a Vercel project.
+Each Vercel environment (production, preview, development) is rotated
+independently and receives its own GCP service account key.
+
+For each configured provider the script:
+  1. Creates a new key (GCP service account key / Sentry project key)
+  2. Updates the Vercel environment variable for each targeted environment
+  3. Triggers a redeployment and waits for it to finish
+  4. Deletes the old key (skippable with --no-invalidate)
+
+Providers are auto-detected from existing Vercel env var names:
+  Firebase  FIREBASE_SERVICE_ACCOUNT or FIREBASE_PRIVATE_KEY
+  Sentry    SENTRY_DSN or NEXT_PUBLIC_SENTRY_DSN
+
+OPTIONS:
+  --env <env>           Which Vercel environment to rotate. One of:
+                          production   Vercel production environment
+                          preview      Vercel preview environment (alias: staging)
+                          development  Vercel development environment
+                          all          All environments that have the key set,
+                                       plus any that are missing it (default)
+  --no-invalidate       Skip deleting old keys after redeployment
+  -h, --help            Show this help
+
+REQUIRED ENVIRONMENT VARIABLES:
+  VERCEL_TOKEN          Vercel API token with project read/write access
+
+OPTIONAL ENVIRONMENT VARIABLES:
+  VERCEL_PROJECT_ID     Vercel project ID (auto-detected from .vercel/project.json)
+  VERCEL_TEAM_ID        Vercel team/org ID (auto-detected from .vercel/project.json)
+  SENTRY_AUTH_TOKEN     Sentry API token (required when Sentry DSN is present)
+  SENTRY_ORG            Sentry organization slug (required with Sentry rotation)
+  SENTRY_PROJECT        Sentry project slug (required with Sentry rotation)
+  SENTRY_URL            Sentry base URL (default: https://sentry.io)
+  GCLOUD_PROJECT        GCP project ID (auto-detected from service account JSON)
+EOF
+}
+
+# ─── Logging ──────────────────────────────────────────────────────────────────
+
+log()  { echo "[$SCRIPT_NAME] $*"; }
+warn() { echo "[$SCRIPT_NAME] WARNING: $*" >&2; }
+err()  { echo "[$SCRIPT_NAME] ERROR: $*" >&2; exit 1; }
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env)
+        TARGET_ENV="${2:-}"
+        [[ "$TARGET_ENV" =~ ^(production|preview|staging|development|all)$ ]] \
+          || err "--env must be one of: production, preview, staging, development, all"
+        # Normalise alias
+        [[ "$TARGET_ENV" == "staging" ]] && TARGET_ENV="preview"
+        shift 2
+        ;;
+      --no-invalidate)
+        INVALIDATE_KEYS=false
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        err "Unknown option: $1. Run '$SCRIPT_NAME --help' for usage."
+        ;;
+    esac
+  done
+}
+
+# ─── Prerequisites ────────────────────────────────────────────────────────────
+
+check_prereqs() {
+  local missing=""
+
+  command -v vercel &>/dev/null || missing="${missing} vercel"
+  command -v gcloud  &>/dev/null || missing="${missing} gcloud"
+  command -v jq      &>/dev/null || missing="${missing} jq"
+  command -v curl    &>/dev/null || missing="${missing} curl"
+
+  if [[ -n "$missing" ]]; then
+    err "Missing required tools:$missing"
+  fi
+
+  [[ -n "${VERCEL_TOKEN:-}" ]] || err "VERCEL_TOKEN environment variable is required"
+
+  if ! vercel whoami &>/dev/null; then
+    err "Vercel CLI not authenticated. Run: vercel login"
+  fi
+
+  TEMP_DIR="$(mktemp -d)"
+}
+
+# ─── Project detection ────────────────────────────────────────────────────────
+
+detect_project() {
+  if [[ -f ".vercel/project.json" ]]; then
+    VERCEL_PROJECT_ID="${VERCEL_PROJECT_ID:-$(jq -r '.projectId' .vercel/project.json)}"
+    if [[ -z "${VERCEL_TEAM_ID:-}" ]]; then
+      VERCEL_TEAM_ID="$(jq -r '.orgId // empty' .vercel/project.json)"
+    fi
+  fi
+
+  [[ -n "${VERCEL_PROJECT_ID:-}" ]] \
+    || err "Could not detect Vercel project ID. Set VERCEL_PROJECT_ID or run from a Vercel project directory."
+
+  log "Project: $VERCEL_PROJECT_ID${VERCEL_TEAM_ID:+ (team: $VERCEL_TEAM_ID)}"
+}
+
+# ─── Vercel API helpers ───────────────────────────────────────────────────────
+
+vercel_api() {
+  local path="$1"
+  local method="${2:-GET}"
+  local data="${3:-}"
+
+  local url="${VERCEL_API}${path}"
+  if [[ -n "${VERCEL_TEAM_ID:-}" ]]; then
+    if [[ "$url" == *"?"* ]]; then
+      url="${url}&teamId=${VERCEL_TEAM_ID}"
+    else
+      url="${url}?teamId=${VERCEL_TEAM_ID}"
+    fi
+  fi
+
+  if [[ -n "$data" ]]; then
+    curl -sf -X "$method" \
+      -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$data" "$url"
+  else
+    curl -sf -X "$method" \
+      -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+      -H "Content-Type: application/json" \
+      "$url"
+  fi
+}
+
+# Returns the decrypted value of a Vercel env var by its record ID.
+# Uses the /v1 endpoint which returns the plaintext value.
+get_env_value() {
+  local env_id="$1"
+  vercel_api "/v1/projects/${VERCEL_PROJECT_ID}/env/${env_id}" | jq -r '.value'
+}
+
+# Returns raw JSON array of all env var records from the Vercel API.
+list_env_vars() {
+  vercel_api "/v9/projects/${VERCEL_PROJECT_ID}/env"
+}
+
+# Returns the Vercel API env record (JSON) for a specific key and target
+# environment, or empty string if not found.
+find_env_record() {
+  local key="$1"
+  local target="$2"   # production | preview | development
+  local all_envs="$3" # pre-fetched JSON from list_env_vars
+
+  echo "$all_envs" | jq -r \
+    --arg k "$key" --arg t "$target" \
+    '.envs[] | select(.key == $k and (.target | index($t) != null))'
+}
+
+# Creates a single Vercel env var record for one target environment.
+# Uses jq --arg for the value to correctly handle newlines and special chars.
+create_env_record() {
+  local key="$1"
+  local value="$2"
+  local target="$3"  # production | preview | development
+
+  local payload
+  payload="$(jq -n --arg k "$key" --arg v "$value" --arg t "$target" \
+    '{key: $k, value: $v, target: [$t], type: "encrypted"}')"
+
+  vercel_api "/v10/projects/${VERCEL_PROJECT_ID}/env" POST "$payload"
+}
+
+# Deletes a Vercel env var record by its ID.
+delete_env_record() {
+  local env_id="$1"
+  vercel_api "/v9/projects/${VERCEL_PROJECT_ID}/env/${env_id}" DELETE >/dev/null
+}
+
+# Sets (replace or create) a Vercel env var for a specific target environment.
+# Deletes any existing record for that key+target before creating the new one.
+# Returns the new record ID via stdout.
+set_env_for_target() {
+  local key="$1"
+  local value="$2"
+  local target="$3"
+  local all_envs="$4"
+
+  # Delete existing record for this key in this specific target
+  local existing_id
+  existing_id="$(echo "$all_envs" | jq -r \
+    --arg k "$key" --arg t "$target" \
+    'first(.envs[] | select(.key == $k and (.target | index($t) != null)) | .id) // empty')"
+
+  if [[ -n "$existing_id" ]]; then
+    delete_env_record "$existing_id"
+    log "  Removed old $key ($target, id: $existing_id)"
+  fi
+
+  local result
+  result="$(create_env_record "$key" "$value" "$target")"
+
+  # Read back to confirm — a null id means the record wasn't actually saved
+  local new_id
+  new_id="$(echo "$result" | jq -r '.id // empty')"
+  if [[ -z "$new_id" ]]; then
+    # Attempt a read-back to see if it landed anyway
+    local all_envs_after
+    all_envs_after="$(list_env_vars)"
+    new_id="$(echo "$all_envs_after" | jq -r \
+      --arg k "$key" --arg t "$target" \
+      'first(.envs[] | select(.key == $k and (.target | index($t) != null)) | .id) // empty')"
+    [[ -n "$new_id" ]] \
+      || err "Failed to confirm $key was saved for $target after write"
+  fi
+
+  log "  Set $key for $target (id: $new_id)"
+  echo "$new_id"
+}
+
+# ─── Target resolution ────────────────────────────────────────────────────────
+
+# Vercel environment names to operate on.
+# "all" expands to the three canonical environments; each provider's rotation
+# function will skip environments that have no existing key and add the key to
+# environments that are missing it (based on the project's actual configuration).
+target_envs() {
+  case "$TARGET_ENV" in
+    production)  echo "production" ;;
+    preview)     echo "preview" ;;
+    development) echo "development" ;;
+    all)         printf 'production\npreview\ndevelopment' ;;
+  esac
+}
+
+# ─── Provider detection ───────────────────────────────────────────────────────
+
+detect_providers() {
+  log "Detecting configured providers..."
+
+  local env_keys
+  env_keys="$(list_env_vars | jq -r '.envs[].key')"
+
+  if echo "$env_keys" | grep -qE '^(FIREBASE_SERVICE_ACCOUNT|FIREBASE_PRIVATE_KEY)$'; then
+    HAS_FIREBASE=true
+    log "  Firebase: service account keys detected"
+  else
+    log "  Firebase: no service account keys found — skipping"
+  fi
+
+  if echo "$env_keys" | grep -qE '^(SENTRY_DSN|NEXT_PUBLIC_SENTRY_DSN)$'; then
+    HAS_SENTRY=true
+    log "  Sentry: DSN detected"
+  else
+    log "  Sentry: no DSN found — skipping"
+  fi
+
+  if [[ "$HAS_FIREBASE" == false && "$HAS_SENTRY" == false ]]; then
+    err "No Firebase or Sentry keys found in this Vercel project — nothing to rotate."
+  fi
+}
+
+# ─── Firebase rotation ────────────────────────────────────────────────────────
+
+# Determines which service account pattern the project uses, extracts the
+# service account email and GCP project, then returns via globals.
+# Sets: FIREBASE_SA_EMAIL, FIREBASE_GCP_PROJECT, FIREBASE_KEY_PATTERN
+# FIREBASE_KEY_PATTERN is one of: "json" | "split"
+detect_firebase_pattern() {
+  local all_envs="$1"
+
+  local sa_json_records private_key_records
+  sa_json_records="$(echo "$all_envs" | jq -r '.envs[] | select(.key == "FIREBASE_SERVICE_ACCOUNT") | .id')"
+  private_key_records="$(echo "$all_envs" | jq -r '.envs[] | select(.key == "FIREBASE_PRIVATE_KEY") | .id')"
+
+  if [[ -n "$sa_json_records" ]]; then
+    FIREBASE_KEY_PATTERN="json"
+    # Read the first available service account JSON to extract metadata
+    local first_id
+    first_id="$(echo "$sa_json_records" | head -1)"
+    local sa_json
+    sa_json="$(get_env_value "$first_id")"
+    FIREBASE_SA_EMAIL="$(echo "$sa_json" | jq -r '.client_email')"
+    FIREBASE_GCP_PROJECT="${GCLOUD_PROJECT:-$(echo "$sa_json" | jq -r '.project_id // empty')}"
+
+  elif [[ -n "$private_key_records" ]]; then
+    FIREBASE_KEY_PATTERN="split"
+    # Read client_email from the first available record
+    local ce_records
+    ce_records="$(echo "$all_envs" | jq -r '.envs[] | select(.key == "FIREBASE_CLIENT_EMAIL") | .id')"
+    [[ -n "$ce_records" ]] \
+      || err "FIREBASE_CLIENT_EMAIL not found in Vercel (required alongside FIREBASE_PRIVATE_KEY)"
+    FIREBASE_SA_EMAIL="$(get_env_value "$(echo "$ce_records" | head -1)")"
+
+    # GCP project from env var or from any FIREBASE_PROJECT_ID record
+    if [[ -z "${GCLOUD_PROJECT:-}" ]]; then
+      local pid_records
+      pid_records="$(echo "$all_envs" | jq -r '.envs[] | select(.key == "FIREBASE_PROJECT_ID") | .id')"
+      if [[ -n "$pid_records" ]]; then
+        FIREBASE_GCP_PROJECT="$(get_env_value "$(echo "$pid_records" | head -1)")"
+      fi
+    else
+      FIREBASE_GCP_PROJECT="$GCLOUD_PROJECT"
+    fi
+  fi
+
+  [[ -n "${FIREBASE_SA_EMAIL:-}" ]]    || err "Could not extract service account email"
+  [[ -n "${FIREBASE_GCP_PROJECT:-}" ]] \
+    || err "Could not detect GCP project. Set GCLOUD_PROJECT or ensure project_id is in the service account JSON."
+
+  log "  Service account : $FIREBASE_SA_EMAIL"
+  log "  GCP project     : $FIREBASE_GCP_PROJECT"
+}
+
+# Finds the private_key_id currently stored for a given Vercel environment.
+# Returns empty string if not found.
+get_firebase_key_id_for_env() {
+  local vercel_env="$1"
+  local all_envs="$2"
+
+  if [[ "${FIREBASE_KEY_PATTERN:-}" == "json" ]]; then
+    local record_id
+    record_id="$(echo "$all_envs" | jq -r \
+      --arg t "$vercel_env" \
+      'first(.envs[] | select(.key == "FIREBASE_SERVICE_ACCOUNT" and (.target | index($t) != null)) | .id) // empty')"
+    if [[ -n "$record_id" ]]; then
+      get_env_value "$record_id" | jq -r '.private_key_id // empty'
+    fi
+  else
+    local record_id
+    record_id="$(echo "$all_envs" | jq -r \
+      --arg t "$vercel_env" \
+      'first(.envs[] | select(.key == "FIREBASE_PRIVATE_KEY_ID" and (.target | index($t) != null)) | .id) // empty')"
+    if [[ -n "$record_id" ]]; then
+      get_env_value "$record_id"
+    fi
+  fi
+}
+
+# Creates a new GCP user-managed service account key and returns the path to
+# the JSON file (caller must ensure file is eventually deleted).
+create_gcp_key() {
+  local output_file="$1"
+  gcloud iam service-accounts keys create "$output_file" \
+    --iam-account="$FIREBASE_SA_EMAIL" \
+    --project="$FIREBASE_GCP_PROJECT" \
+    --quiet 2>/dev/null
+}
+
+# Lists only user-managed service account keys for the project's SA.
+list_user_managed_gcp_keys() {
+  gcloud iam service-accounts keys list \
+    --iam-account="$FIREBASE_SA_EMAIL" \
+    --project="$FIREBASE_GCP_PROJECT" \
+    --managed-by=user \
+    --format='value(name.basename())' 2>/dev/null
+}
+
+rotate_firebase() {
+  log "Rotating Firebase service account keys..."
+
+  local all_envs
+  all_envs="$(list_env_vars)"
+
+  detect_firebase_pattern "$all_envs"
+  log "  Key pattern: ${FIREBASE_KEY_PATTERN}"
+
+  # Determine which environments to rotate and which old keys to record.
+  # For "all", we always rotate production/preview/development. If an env is
+  # missing the key, we add it with a fresh GCP key.
+  local rotated_any=false
+
+  while IFS= read -r vercel_env; do
+    [[ -z "$vercel_env" ]] && continue
+
+    log "  [$vercel_env] Rotating..."
+
+    # Read old key ID before creating the new one
+    local old_key_id
+    old_key_id="$(get_firebase_key_id_for_env "$vercel_env" "$all_envs")"
+    if [[ -n "$old_key_id" ]]; then
+      log "  [$vercel_env] Current key ID: $old_key_id"
+    else
+      log "  [$vercel_env] No existing key found — will add"
+    fi
+
+    # Create a fresh GCP service account key for this specific environment
+    local new_key_file="$TEMP_DIR/key-${vercel_env}.json"
+    create_gcp_key "$new_key_file"
+
+    local new_sa_json new_key_id
+    new_sa_json="$(cat "$new_key_file")"
+    new_key_id="$(echo "$new_sa_json" | jq -r '.private_key_id')"
+    log "  [$vercel_env] New key ID: $new_key_id"
+
+    # Re-fetch env vars before each write (state may have changed)
+    local current_envs
+    current_envs="$(list_env_vars)"
+
+    if [[ "${FIREBASE_KEY_PATTERN:-}" == "json" ]]; then
+      set_env_for_target \
+        "FIREBASE_SERVICE_ACCOUNT" \
+        "$(echo "$new_sa_json" | jq -c .)" \
+        "$vercel_env" \
+        "$current_envs" >/dev/null
+    else
+      local new_private_key new_private_key_id
+      new_private_key="$(echo "$new_sa_json" | jq -r '.private_key')"
+      new_private_key_id="$(echo "$new_sa_json" | jq -r '.private_key_id')"
+
+      set_env_for_target "FIREBASE_PRIVATE_KEY"    "$new_private_key"    "$vercel_env" "$current_envs" >/dev/null
+      set_env_for_target "FIREBASE_PRIVATE_KEY_ID" "$new_private_key_id" "$vercel_env" "$current_envs" >/dev/null
+      # client_email, project_id, and other static fields don't change between keys
+    fi
+
+    # Record old key for post-redeployment invalidation (only if one existed)
+    if [[ -n "$old_key_id" ]]; then
+      OLD_FIREBASE_ENVS+=("$vercel_env")
+      OLD_FIREBASE_KEYS+=("$old_key_id")
+    fi
+
+    rotated_any=true
+
+  done < <(target_envs)
+
+  [[ "$rotated_any" == true ]] || err "No Firebase keys rotated — check --env and project configuration"
+
+  log "Firebase key rotation complete."
+}
+
+# ─── Sentry rotation ──────────────────────────────────────────────────────────
+
+sentry_api() {
+  local path="$1"
+  local method="${2:-GET}"
+  local data="${3:-}"
+
+  [[ -n "${SENTRY_AUTH_TOKEN:-}" ]] \
+    || err "SENTRY_AUTH_TOKEN is required for Sentry key rotation"
+
+  if [[ -n "$data" ]]; then
+    curl -sf -X "$method" \
+      -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$data" \
+      "${SENTRY_URL}/api/0${path}"
+  else
+    curl -sf -X "$method" \
+      -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+      -H "Content-Type: application/json" \
+      "${SENTRY_URL}/api/0${path}"
+  fi
+}
+
+rotate_sentry() {
+  log "Rotating Sentry client key..."
+
+  [[ -n "${SENTRY_AUTH_TOKEN:-}" ]] || err "SENTRY_AUTH_TOKEN is required for Sentry rotation"
+  [[ -n "${SENTRY_ORG:-}" ]]        || err "SENTRY_ORG is required for Sentry rotation"
+  [[ -n "${SENTRY_PROJECT:-}" ]]    || err "SENTRY_PROJECT is required for Sentry rotation"
+
+  SENTRY_ORG_SLUG="$SENTRY_ORG"
+  SENTRY_PROJECT_SLUG="$SENTRY_PROJECT"
+
+  local all_envs
+  all_envs="$(list_env_vars)"
+
+  # Find which DSN env var name is in use and get its value from the first
+  # available environment record (DSN is typically shared across all envs)
+  local dsn_key_name dsn_env_id dsn_env_id_found
+  dsn_env_id_found=""
+  for candidate in "NEXT_PUBLIC_SENTRY_DSN" "SENTRY_DSN"; do
+    local found_id
+    found_id="$(echo "$all_envs" | jq -r \
+      --arg k "$candidate" 'first(.envs[] | select(.key == $k) | .id) // empty')"
+    if [[ -n "$found_id" ]]; then
+      dsn_key_name="$candidate"
+      dsn_env_id_found="$found_id"
+      break
+    fi
+  done
+
+  [[ -n "${dsn_env_id_found:-}" ]] \
+    || err "Could not find SENTRY_DSN or NEXT_PUBLIC_SENTRY_DSN in Vercel"
+
+  local current_dsn
+  current_dsn="$(get_env_value "$dsn_env_id_found")"
+  log "  DSN env var: $dsn_key_name"
+
+  # List Sentry project keys and find the one matching the current DSN
+  local current_keys
+  current_keys="$(sentry_api "/projects/${SENTRY_ORG_SLUG}/${SENTRY_PROJECT_SLUG}/keys/")"
+
+  local dsn_public_key old_key_id
+  dsn_public_key="$(echo "$current_dsn" | sed -E 's|https?://([^@]+)@.*|\1|')"
+  old_key_id="$(echo "$current_keys" | jq -r \
+    --arg pk "$dsn_public_key" \
+    'first(.[] | select(.dsn.public | test($pk; "i")) | .id) // empty')"
+
+  if [[ -z "${old_key_id:-}" ]]; then
+    warn "Could not match current DSN to a Sentry project key — old key will not be invalidated"
+  else
+    log "  Current Sentry key ID: $old_key_id"
+  fi
+
+  # Create new Sentry project key
+  log "  Creating new Sentry project key..."
+  local label="rotated-$(date +%Y%m%d)"
+  local new_key
+  new_key="$(sentry_api \
+    "/projects/${SENTRY_ORG_SLUG}/${SENTRY_PROJECT_SLUG}/keys/" \
+    POST \
+    "$(jq -n --arg n "$label" '{name: $n}')")"
+
+  local new_dsn new_key_id
+  new_dsn="$(echo "$new_key" | jq -r '.dsn.public')"
+  new_key_id="$(echo "$new_key" | jq -r '.id')"
+  log "  New Sentry key ID: $new_key_id"
+
+  # Update all target environments with the new DSN
+  while IFS= read -r vercel_env; do
+    [[ -z "$vercel_env" ]] && continue
+    local current_envs
+    current_envs="$(list_env_vars)"
+    set_env_for_target "$dsn_key_name" "$new_dsn" "$vercel_env" "$current_envs" >/dev/null
+  done < <(target_envs)
+
+  OLD_SENTRY_KEY_ID="${old_key_id:-}"
+  log "Sentry key rotation complete."
+}
+
+# ─── Redeployment ─────────────────────────────────────────────────────────────
+
+trigger_redeployments() {
+  log "Triggering redeployments..."
+
+  while IFS= read -r vercel_env; do
+    [[ -z "$vercel_env" ]] && continue
+
+    # Find the latest READY deployment for this environment
+    local list_url
+    list_url="${VERCEL_API}/v6/deployments?projectId=${VERCEL_PROJECT_ID}&target=${vercel_env}&limit=1&state=READY"
+    [[ -n "${VERCEL_TEAM_ID:-}" ]] && list_url="${list_url}&teamId=${VERCEL_TEAM_ID}"
+
+    local deployments latest_id latest_url
+    deployments="$(curl -sf -H "Authorization: Bearer ${VERCEL_TOKEN}" "$list_url")"
+    latest_id="$(echo "$deployments" | jq -r '.deployments[0].uid // empty')"
+    latest_url="$(echo "$deployments" | jq -r '.deployments[0].url // empty')"
+
+    if [[ -z "$latest_id" ]]; then
+      warn "No existing deployment found for '$vercel_env' — skipping redeployment"
+      continue
+    fi
+
+    log "  Redeploying $vercel_env ($latest_url)..."
+    local new_deployment new_id
+    new_deployment="$(vercel_api "/v13/deployments/${latest_id}/redeploy" POST '{}')"
+    new_id="$(echo "$new_deployment" | jq -r '.id')"
+    DEPLOYMENT_IDS+=("$new_id")
+    log "  Queued: $new_id"
+
+  done < <(target_envs)
+}
+
+wait_for_deployments() {
+  local count="${#DEPLOYMENT_IDS[@]}"
+  [[ "$count" -eq 0 ]] && return
+
+  log "Waiting for $count deployment(s) to finish..."
+
+  local i
+  for (( i = 0; i < count; i++ )); do
+    local deployment_id="${DEPLOYMENT_IDS[$i]}"
+    log "  Polling $deployment_id..."
+
+    local attempts=0
+    local max_attempts=60  # 10 min at 10s intervals
+
+    while [[ $attempts -lt $max_attempts ]]; do
+      local status
+      status="$(vercel_api "/v13/deployments/${deployment_id}" | jq -r '.status')"
+
+      case "$status" in
+        READY)
+          log "  $deployment_id → READY"
+          break
+          ;;
+        ERROR|CANCELED)
+          err "Deployment $deployment_id ended with status: $status"
+          ;;
+        *)
+          log "  $deployment_id → $status (retrying in 10s...)"
+          sleep 10
+          ;;
+      esac
+
+      (( attempts++ )) || true
+    done
+
+    [[ $attempts -ge $max_attempts ]] \
+      && err "Deployment $deployment_id timed out after 10 minutes"
+  done
+
+  log "All deployments ready."
+}
+
+# ─── Key invalidation ─────────────────────────────────────────────────────────
+
+invalidate_firebase_keys() {
+  local count="${#OLD_FIREBASE_KEYS[@]}"
+  if [[ "$count" -eq 0 ]]; then
+    warn "No old Firebase key IDs recorded — skipping Firebase invalidation"
+    return
+  fi
+
+  log "Invalidating $count old Firebase key(s) (user-managed only)..."
+
+  # Verify each key is still user-managed before deleting (defensive check)
+  local user_keys
+  user_keys="$(list_user_managed_gcp_keys)"
+
+  local i
+  for (( i = 0; i < count; i++ )); do
+    local vercel_env="${OLD_FIREBASE_ENVS[$i]}"
+    local key_id="${OLD_FIREBASE_KEYS[$i]}"
+
+    if ! echo "$user_keys" | grep -qF "$key_id"; then
+      warn "[$vercel_env] Key $key_id not found in user-managed keys — skipping"
+      continue
+    fi
+
+    log "  [$vercel_env] Deleting key: $key_id"
+    if gcloud iam service-accounts keys delete "$key_id" \
+        --iam-account="$FIREBASE_SA_EMAIL" \
+        --project="$FIREBASE_GCP_PROJECT" \
+        --quiet 2>/dev/null; then
+      log "  [$vercel_env] Deleted."
+    else
+      warn "[$vercel_env] Failed to delete key $key_id — remove manually:"
+      warn "  gcloud iam service-accounts keys delete $key_id --iam-account=$FIREBASE_SA_EMAIL"
+    fi
+  done
+}
+
+invalidate_sentry_key() {
+  if [[ -z "${OLD_SENTRY_KEY_ID:-}" ]]; then
+    warn "No old Sentry key ID recorded — skipping Sentry invalidation"
+    return
+  fi
+
+  log "Invalidating old Sentry key: $OLD_SENTRY_KEY_ID"
+
+  if sentry_api \
+      "/projects/${SENTRY_ORG_SLUG}/${SENTRY_PROJECT_SLUG}/keys/${OLD_SENTRY_KEY_ID}/" \
+      DELETE >/dev/null 2>&1; then
+    log "  Old Sentry key deleted."
+  else
+    warn "Failed to delete Sentry key $OLD_SENTRY_KEY_ID — remove it manually in Sentry project settings."
+  fi
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  parse_args "$@"
+  check_prereqs
+  detect_project
+  detect_providers
+
+  log "Target: $TARGET_ENV | Invalidate after redeployment: $INVALIDATE_KEYS"
+
+  # Phase 1: generate new keys and push to Vercel
+  [[ "$HAS_FIREBASE" == true ]] && rotate_firebase
+  [[ "$HAS_SENTRY"   == true ]] && rotate_sentry
+
+  # Phase 2: redeploy so new env vars take effect
+  trigger_redeployments
+  wait_for_deployments
+
+  # Phase 3: invalidate old keys now that new deployments are live
+  if [[ "$INVALIDATE_KEYS" == true ]]; then
+    log "Invalidating old keys..."
+    [[ "$HAS_FIREBASE" == true ]] && invalidate_firebase_keys
+    [[ "$HAS_SENTRY"   == true ]] && invalidate_sentry_key
+  else
+    log "Skipping key invalidation (--no-invalidate)"
+
+    local i
+    local count="${#OLD_FIREBASE_KEYS[@]}"
+    for (( i = 0; i < count; i++ )); do
+      warn "Old Firebase key to remove: ${OLD_FIREBASE_KEYS[$i]} (${OLD_FIREBASE_ENVS[$i]}, account: $FIREBASE_SA_EMAIL)"
+    done
+    [[ -n "${OLD_SENTRY_KEY_ID:-}" ]] \
+      && warn "Old Sentry key to remove: $OLD_SENTRY_KEY_ID (project: $SENTRY_ORG_SLUG/$SENTRY_PROJECT_SLUG)"
+  fi
+
+  log "Key rotation complete."
+}
+
+main "$@"

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -700,19 +700,28 @@ trigger_redeployments() {
   while IFS= read -r vercel_env; do
     [[ -z "$vercel_env" ]] && continue
 
+    # Vercel's deployment API uses "staging" for preview deployments, not "preview".
+    # "development" has no remote deployment target; the empty-id guard handles it.
+    local deploy_target
+    case "$vercel_env" in
+      production) deploy_target="production" ;;
+      *)          deploy_target="staging" ;;
+    esac
+
     # Find the latest READY deployment for this environment
     local list_url
-    list_url="${VERCEL_API}/v6/deployments?projectId=${VERCEL_PROJECT_ID}&target=${vercel_env}&limit=1&state=READY"
+    list_url="${VERCEL_API}/v6/deployments?projectId=${VERCEL_PROJECT_ID}&target=${deploy_target}&limit=1&state=READY"
     [[ -n "${VERCEL_TEAM_ID:-}" ]] && list_url="${list_url}&teamId=${VERCEL_TEAM_ID}"
 
-    local deployments latest_id latest_url
+    local deployments latest_id latest_url latest_name
     # Strip control characters before parsing: the v6 API occasionally includes
     # non-printable bytes that cause jq to fail or return empty. tr removes
     # everything below 0x20 except TAB (\011), LF (\012), and CR (\015).
-    deployments="$(curl -sf -H "Authorization: Bearer ${VERCEL_TOKEN}" "$list_url" \
+    deployments="$(curl -sf --http1.1 -H "Authorization: Bearer ${VERCEL_TOKEN}" "$list_url" \
       | tr -d '\000-\010\013\014\016-\037')" || true
-    latest_id="$(echo "$deployments" | jq -r '.deployments[0].uid // empty' 2>/dev/null || true)"
-    latest_url="$(echo "$deployments" | jq -r '.deployments[0].url // empty' 2>/dev/null || true)"
+    latest_id="$(echo "$deployments"   | jq -r '.deployments[0].uid  // empty' 2>/dev/null || true)"
+    latest_url="$(echo "$deployments"  | jq -r '.deployments[0].url  // empty' 2>/dev/null || true)"
+    latest_name="$(echo "$deployments" | jq -r '.deployments[0].name // empty' 2>/dev/null || true)"
 
     if [[ -z "$latest_id" ]]; then
       warn "No READY deployment found for '$vercel_env' — skipping redeployment"
@@ -722,7 +731,8 @@ trigger_redeployments() {
     log "  Redeploying $vercel_env ($latest_url)..."
     local new_deployment new_id
     new_deployment="$(vercel_api "/v13/deployments" POST \
-      "$(jq -n --arg id "$latest_id" '{deploymentId: $id}')")"
+      "$(jq -n --arg id "$latest_id" --arg name "$latest_name" --arg target "$deploy_target" \
+           '{deploymentId: $id, name: $name, target: $target}')")"
     new_id="$(echo "$new_deployment" | jq -r '.id')"
     DEPLOYMENT_IDS+=("$new_id")
     log "  Queued: $new_id"

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -68,8 +68,9 @@ OPTIONS:
                           production   Vercel production environment
                           preview      Vercel preview environment (alias: staging)
                           development  Vercel development environment
-                          all          All environments that have the key set,
-                                       plus any that are missing it (default)
+                          all          All environments that already have the key
+                                       configured; unconfigured environments are
+                                       skipped (use --env <env> to explicitly add)
   --no-invalidate       Skip deleting old keys after redeployment
   -h, --help            Show this help
 
@@ -201,18 +202,6 @@ list_env_vars() {
   vercel_api "/v9/projects/${VERCEL_PROJECT_ID}/env"
 }
 
-# Returns the Vercel API env record (JSON) for a specific key and target
-# environment, or empty string if not found.
-find_env_record() {
-  local key="$1"
-  local target="$2"   # production | preview | development
-  local all_envs="$3" # pre-fetched JSON from list_env_vars
-
-  echo "$all_envs" | jq -r \
-    --arg k "$key" --arg t "$target" \
-    '.envs[] | select(.key == $k and (.target | index($t) != null))'
-}
-
 # Creates a single Vercel env var record for one target environment.
 # Uses jq --arg for the value to correctly handle newlines and special chars.
 create_env_record() {
@@ -276,10 +265,8 @@ set_env_for_target() {
 
 # ─── Target resolution ────────────────────────────────────────────────────────
 
-# Vercel environment names to operate on.
-# "all" expands to the three canonical environments; each provider's rotation
-# function will skip environments that have no existing key and add the key to
-# environments that are missing it (based on the project's actual configuration).
+# Vercel environment names to operate on. "all" expands to the three canonical
+# environments; provider rotation functions skip any that have no existing key.
 target_envs() {
   case "$TARGET_ENV" in
     production)  echo "production" ;;
@@ -400,7 +387,7 @@ create_gcp_key() {
   gcloud iam service-accounts keys create "$output_file" \
     --iam-account="$FIREBASE_SA_EMAIL" \
     --project="$FIREBASE_GCP_PROJECT" \
-    --quiet 2>/dev/null
+    --quiet
 }
 
 # Lists only user-managed service account keys for the project's SA.
@@ -409,7 +396,7 @@ list_user_managed_gcp_keys() {
     --iam-account="$FIREBASE_SA_EMAIL" \
     --project="$FIREBASE_GCP_PROJECT" \
     --managed-by=user \
-    --format='value(name.basename())' 2>/dev/null
+    --format='value(name.basename())'
 }
 
 rotate_firebase() {
@@ -580,11 +567,24 @@ rotate_sentry() {
   new_key_id="$(echo "$new_key" | jq -r '.id')"
   log "  New Sentry key ID: $new_key_id"
 
-  # Update all target environments with the new DSN
+  # Update target environments with the new DSN. For "--env all", skip any
+  # environment that has no existing DSN configured (matches Firebase behaviour).
   while IFS= read -r vercel_env; do
     [[ -z "$vercel_env" ]] && continue
     local current_envs
     current_envs="$(list_env_vars)"
+
+    if [[ "$TARGET_ENV" == "all" ]]; then
+      local existing_dsn_id
+      existing_dsn_id="$(echo "$current_envs" | jq -r \
+        --arg k "$dsn_key_name" --arg t "$vercel_env" \
+        'first(.envs[] | select(.key == $k and (.target | index($t) != null)) | .id) // empty')"
+      if [[ -z "$existing_dsn_id" ]]; then
+        log "  [$vercel_env] No existing $dsn_key_name — skipping (use --env $vercel_env to explicitly add)"
+        continue
+      fi
+    fi
+
     set_env_for_target "$dsn_key_name" "$new_dsn" "$vercel_env" "$current_envs" >/dev/null
   done < <(target_envs)
 

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -663,39 +663,54 @@ wait_for_deployments() {
 # ─── Key invalidation ─────────────────────────────────────────────────────────
 
 invalidate_firebase_keys() {
-  local count="${#OLD_FIREBASE_KEYS[@]}"
-  if [[ "$count" -eq 0 ]]; then
-    warn "No old Firebase key IDs recorded — skipping Firebase invalidation"
-    return
-  fi
+  log "Invalidating old Firebase keys (sweeping all non-active user-managed keys)..."
 
-  log "Invalidating $count old Firebase key(s) (user-managed only)..."
+  # Build the set of key IDs currently active in Vercel across all three
+  # standard environments. This is the authoritative "keep" list — anything
+  # outside it is a stray key (old rotation remnants, partially leaked keys,
+  # etc.) and should be removed.
+  local all_envs_fresh
+  all_envs_fresh="$(list_env_vars)"
 
-  # Verify each key is still user-managed before deleting (defensive check)
+  local active_keys=""
+  for check_env in production preview development; do
+    local kid
+    kid="$(get_firebase_key_id_for_env "$check_env" "$all_envs_fresh")"
+    if [[ -n "$kid" ]]; then
+      active_keys="${active_keys} ${kid}"
+      log "  Active key [$check_env]: $kid"
+    fi
+  done
+
   local user_keys
   user_keys="$(list_user_managed_gcp_keys)"
 
-  local i
-  for (( i = 0; i < count; i++ )); do
-    local vercel_env="${OLD_FIREBASE_ENVS[$i]}"
-    local key_id="${OLD_FIREBASE_KEYS[$i]}"
+  local deleted=0
+  while IFS= read -r key_id; do
+    [[ -z "$key_id" ]] && continue
 
-    if ! echo "$user_keys" | grep -qF "$key_id"; then
-      warn "[$vercel_env] Key $key_id not found in user-managed keys — skipping"
-      continue
+    if echo "$active_keys" | grep -qF "$key_id"; then
+      continue  # currently active — keep
     fi
 
-    log "  [$vercel_env] Deleting key: $key_id"
+    log "  Deleting stray key: $key_id"
     if gcloud iam service-accounts keys delete "$key_id" \
         --iam-account="$FIREBASE_SA_EMAIL" \
         --project="$FIREBASE_GCP_PROJECT" \
         --quiet 2>/dev/null; then
-      log "  [$vercel_env] Deleted."
+      log "  Deleted: $key_id"
+      (( deleted++ )) || true
     else
-      warn "[$vercel_env] Failed to delete key $key_id — remove manually:"
+      warn "Failed to delete key $key_id — remove manually:"
       warn "  gcloud iam service-accounts keys delete $key_id --iam-account=$FIREBASE_SA_EMAIL"
     fi
-  done
+  done <<< "$user_keys"
+
+  if [[ $deleted -eq 0 ]]; then
+    log "  No stray keys found."
+  else
+    log "  Deleted $deleted stray key(s)."
+  fi
 }
 
 invalidate_sentry_key() {

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -276,7 +276,7 @@ target_envs() {
     production)  echo "production" ;;
     preview)     echo "preview" ;;
     development) echo "development" ;;
-    all)         printf 'production\npreview\ndevelopment' ;;
+    all)         printf 'production\npreview\ndevelopment\n' ;;
   esac
 }
 
@@ -706,12 +706,16 @@ trigger_redeployments() {
     [[ -n "${VERCEL_TEAM_ID:-}" ]] && list_url="${list_url}&teamId=${VERCEL_TEAM_ID}"
 
     local deployments latest_id latest_url
-    deployments="$(curl -sf -H "Authorization: Bearer ${VERCEL_TOKEN}" "$list_url")"
-    latest_id="$(echo "$deployments" | jq -r '.deployments[0].uid // empty')"
-    latest_url="$(echo "$deployments" | jq -r '.deployments[0].url // empty')"
+    # Strip control characters before parsing: the v6 API occasionally includes
+    # non-printable bytes that cause jq to fail or return empty. tr removes
+    # everything below 0x20 except TAB (\011), LF (\012), and CR (\015).
+    deployments="$(curl -sf -H "Authorization: Bearer ${VERCEL_TOKEN}" "$list_url" \
+      | tr -d '\000-\010\013\014\016-\037')" || true
+    latest_id="$(echo "$deployments" | jq -r '.deployments[0].uid // empty' 2>/dev/null || true)"
+    latest_url="$(echo "$deployments" | jq -r '.deployments[0].url // empty' 2>/dev/null || true)"
 
     if [[ -z "$latest_id" ]]; then
-      warn "No existing deployment found for '$vercel_env' — skipping redeployment"
+      warn "No READY deployment found for '$vercel_env' — skipping redeployment"
       continue
     fi
 

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -19,11 +19,15 @@ VERCEL_TEAM_ID="${VERCEL_TEAM_ID:-}"
 HAS_FIREBASE=false
 HAS_SENTRY=false
 
-# Maps Vercel env name → old GCP key ID (populated during rotation, consumed
-# during invalidation). Format: "production:KEY_ID preview:KEY_ID ..."
-# Stored as parallel arrays for bash 3.2 compatibility.
+# Old key tracking (parallel arrays, bash 3.2 compatible):
+#   OLD_FIREBASE_ENVS[i]        — Vercel environment name
+#   OLD_FIREBASE_KEYS[i]        — GCP key ID that was replaced
+#   OLD_FIREBASE_SA_EMAILS[i]   — SA email that owns the key
+#   OLD_FIREBASE_GCP_PROJECTS[i]— GCP project for that SA
 OLD_FIREBASE_ENVS=()
 OLD_FIREBASE_KEYS=()
+OLD_FIREBASE_SA_EMAILS=()
+OLD_FIREBASE_GCP_PROJECTS=()
 FIREBASE_SA_EMAIL=""
 FIREBASE_GCP_PROJECT=""
 
@@ -380,21 +384,63 @@ get_firebase_key_id_for_env() {
   fi
 }
 
+# Returns "sa_email gcp_project" for the Firebase service account used by a
+# specific Vercel environment, or empty string if that environment has no key.
+# Used to ensure each environment's new key is created under the correct SA
+# (e.g. preview/development use the staging SA, production uses the prod SA).
+get_firebase_sa_for_env() {
+  local vercel_env="$1"
+  local all_envs="$2"
+
+  if [[ "${FIREBASE_KEY_PATTERN:-}" == "json" ]]; then
+    local record_id
+    record_id="$(echo "$all_envs" | jq -r \
+      --arg t "$vercel_env" \
+      'first(.envs[] | select(.key == "FIREBASE_SERVICE_ACCOUNT" and (.target | index($t) != null)) | .id) // empty')"
+    if [[ -n "$record_id" ]]; then
+      local sa_json email project
+      sa_json="$(get_env_value "$record_id")"
+      email="$(echo "$sa_json" | jq -r '.client_email // empty')"
+      project="$(echo "$sa_json" | jq -r '.project_id // empty')"
+      [[ -n "$email" ]] && echo "$email $project"
+    fi
+  else
+    local ce_id
+    ce_id="$(echo "$all_envs" | jq -r \
+      --arg t "$vercel_env" \
+      'first(.envs[] | select(.key == "FIREBASE_CLIENT_EMAIL" and (.target | index($t) != null)) | .id) // empty')"
+    if [[ -n "$ce_id" ]]; then
+      local email project=""
+      email="$(get_env_value "$ce_id")"
+      local pid_id
+      pid_id="$(echo "$all_envs" | jq -r \
+        --arg t "$vercel_env" \
+        'first(.envs[] | select(.key == "FIREBASE_PROJECT_ID" and (.target | index($t) != null)) | .id) // empty')"
+      [[ -n "$pid_id" ]] && project="$(get_env_value "$pid_id")"
+      [[ -n "$email" ]] && echo "$email ${project:-$FIREBASE_GCP_PROJECT}"
+    fi
+  fi
+}
+
 # Creates a new GCP user-managed service account key and returns the path to
 # the JSON file (caller must ensure file is eventually deleted).
 create_gcp_key() {
   local output_file="$1"
+  local sa_email="$2"
+  local gcp_project="$3"
   gcloud iam service-accounts keys create "$output_file" \
-    --iam-account="$FIREBASE_SA_EMAIL" \
-    --project="$FIREBASE_GCP_PROJECT" \
+    --iam-account="$sa_email" \
+    --project="$gcp_project" \
     --quiet
 }
 
-# Lists only user-managed service account keys for the project's SA.
+# Lists only user-managed service account keys for the given SA.
 list_user_managed_gcp_keys() {
+  local sa_email="$1"
+  local gcp_project="$2"
   gcloud iam service-accounts keys list \
-    --iam-account="$FIREBASE_SA_EMAIL" \
-    --project="$FIREBASE_GCP_PROJECT" \
+    --iam-account="$sa_email" \
+    --project="$gcp_project" \
     --managed-by=user \
     --format='value(name.basename())'
 }
@@ -432,11 +478,36 @@ rotate_firebase() {
       log "  [$vercel_env] Current key ID: $old_key_id"
     fi
 
-    log "  [$vercel_env] Rotating..."
+    # Determine which Firebase SA owns this Vercel environment. In a two-env
+    # project, Production uses the prod SA and Preview/Development use the
+    # staging SA. Read from the existing Vercel record — the single global
+    # FIREBASE_SA_EMAIL comes from whichever record the API returns first and
+    # is not reliable across environments.
+    local env_sa_info env_sa_email env_gcp_project
+    env_sa_info="$(get_firebase_sa_for_env "$vercel_env" "$all_envs")"
+    env_sa_email="${env_sa_info%% *}"
+    env_gcp_project="${env_sa_info##* }"
+
+    # If adding to an environment with no existing key, infer the SA:
+    # preview/development inherit from whichever peer has a key; production
+    # falls back to the global (set by detect_firebase_pattern).
+    if [[ -z "$env_sa_email" ]]; then
+      if [[ "$vercel_env" != "production" ]]; then
+        local peer_info
+        peer_info="$(get_firebase_sa_for_env "preview" "$all_envs")"
+        [[ -z "$peer_info" ]] && peer_info="$(get_firebase_sa_for_env "development" "$all_envs")"
+        env_sa_email="${peer_info%% *}"
+        env_gcp_project="${peer_info##* }"
+      fi
+      [[ -z "$env_sa_email" ]] && env_sa_email="$FIREBASE_SA_EMAIL"
+      [[ -z "$env_gcp_project" ]] && env_gcp_project="$FIREBASE_GCP_PROJECT"
+    fi
+
+    log "  [$vercel_env] Rotating... (SA: $env_sa_email)"
 
     # Create a fresh GCP service account key for this specific environment
     local new_key_file="$TEMP_DIR/key-${vercel_env}.json"
-    create_gcp_key "$new_key_file"
+    create_gcp_key "$new_key_file" "$env_sa_email" "$env_gcp_project"
 
     local new_sa_json new_key_id
     new_sa_json="$(cat "$new_key_file")"
@@ -467,6 +538,8 @@ rotate_firebase() {
     if [[ -n "$old_key_id" ]]; then
       OLD_FIREBASE_ENVS+=("$vercel_env")
       OLD_FIREBASE_KEYS+=("$old_key_id")
+      OLD_FIREBASE_SA_EMAILS+=("$env_sa_email")
+      OLD_FIREBASE_GCP_PROJECTS+=("$env_gcp_project")
     fi
 
     rotated_any=true
@@ -672,52 +745,71 @@ wait_for_deployments() {
 invalidate_firebase_keys() {
   log "Invalidating old Firebase keys (sweeping all non-active user-managed keys)..."
 
-  # Build the set of key IDs currently active in Vercel across all three
-  # standard environments. This is the authoritative "keep" list — anything
-  # outside it is a stray key (old rotation remnants, partially leaked keys,
-  # etc.) and should be removed.
   local all_envs_fresh
   all_envs_fresh="$(list_env_vars)"
 
+  # Build the active key ID set and discover all unique Firebase SAs in use.
+  # Checking all three standard environments handles two-env projects (where
+  # production uses one SA and preview/development use the staging SA) as well
+  # as prod-only projects (single SA across all environments).
   local active_keys=""
+  local sa_pair_list=""  # "email:project" entries, space-separated, deduplicated
+
   for check_env in production preview development; do
-    local kid
+    local kid sa_info
     kid="$(get_firebase_key_id_for_env "$check_env" "$all_envs_fresh")"
+    sa_info="$(get_firebase_sa_for_env "$check_env" "$all_envs_fresh")"
+
     if [[ -n "$kid" ]]; then
       active_keys="${active_keys} ${kid}"
       log "  Active key [$check_env]: $kid"
     fi
+
+    if [[ -n "$sa_info" ]]; then
+      local pair="${sa_info%% *}:${sa_info##* }"  # "email:project"
+      if ! echo "$sa_pair_list" | grep -qF "$pair"; then
+        sa_pair_list="${sa_pair_list} ${pair}"
+      fi
+    fi
   done
 
-  local user_keys
-  user_keys="$(list_user_managed_gcp_keys)"
+  # Sweep non-active user-managed keys from every SA referenced in this project
+  local deleted_total=0
+  local pair
+  for pair in $sa_pair_list; do
+    local sa_email="${pair%%:*}"
+    local gcp_project="${pair#*:}"
+    log "  Sweeping SA: $sa_email"
 
-  local deleted=0
-  while IFS= read -r key_id; do
-    [[ -z "$key_id" ]] && continue
+    local user_keys
+    user_keys="$(list_user_managed_gcp_keys "$sa_email" "$gcp_project")"
 
-    if echo "$active_keys" | grep -qF "$key_id"; then
-      continue  # currently active — keep
-    fi
+    local deleted=0
+    while IFS= read -r key_id; do
+      [[ -z "$key_id" ]] && continue
+      if echo "$active_keys" | grep -qF "$key_id"; then
+        continue  # currently active — keep
+      fi
+      log "  Deleting stray key: $key_id"
+      if gcloud iam service-accounts keys delete "$key_id" \
+          --iam-account="$sa_email" \
+          --project="$gcp_project" \
+          --quiet; then
+        log "  Deleted: $key_id"
+        (( deleted++ )) || true
+      else
+        warn "Failed to delete key $key_id — remove manually:"
+        warn "  gcloud iam service-accounts keys delete $key_id --iam-account=$sa_email"
+      fi
+    done <<< "$user_keys"
 
-    log "  Deleting stray key: $key_id"
-    if gcloud iam service-accounts keys delete "$key_id" \
-        --iam-account="$FIREBASE_SA_EMAIL" \
-        --project="$FIREBASE_GCP_PROJECT" \
-        --quiet 2>/dev/null; then
-      log "  Deleted: $key_id"
-      (( deleted++ )) || true
+    if [[ $deleted -eq 0 ]]; then
+      log "  No stray keys for $sa_email."
     else
-      warn "Failed to delete key $key_id — remove manually:"
-      warn "  gcloud iam service-accounts keys delete $key_id --iam-account=$FIREBASE_SA_EMAIL"
+      log "  Deleted $deleted stray key(s) for $sa_email."
+      (( deleted_total += deleted )) || true
     fi
-  done <<< "$user_keys"
-
-  if [[ $deleted -eq 0 ]]; then
-    log "  No stray keys found."
-  else
-    log "  Deleted $deleted stray key(s)."
-  fi
+  done
 }
 
 invalidate_sentry_key() {
@@ -766,7 +858,7 @@ main() {
     local i
     local count="${#OLD_FIREBASE_KEYS[@]}"
     for (( i = 0; i < count; i++ )); do
-      warn "Old Firebase key to remove: ${OLD_FIREBASE_KEYS[$i]} (${OLD_FIREBASE_ENVS[$i]}, account: $FIREBASE_SA_EMAIL)"
+      warn "Old Firebase key to remove: ${OLD_FIREBASE_KEYS[$i]} (${OLD_FIREBASE_ENVS[$i]}, account: ${OLD_FIREBASE_SA_EMAILS[$i]:-$FIREBASE_SA_EMAIL})"
     done
     [[ -n "${OLD_SENTRY_KEY_ID:-}" ]] \
       && warn "Old Sentry key to remove: $OLD_SENTRY_KEY_ID (project: $SENTRY_ORG_SLUG/$SENTRY_PROJECT_SLUG)"

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -182,12 +182,12 @@ vercel_api() {
   fi
 
   if [[ -n "$data" ]]; then
-    curl -sf -X "$method" \
+    curl -sf --http1.1 -X "$method" \
       -H "Authorization: Bearer ${VERCEL_TOKEN}" \
       -H "Content-Type: application/json" \
       -d "$data" "$url"
   else
-    curl -sf -X "$method" \
+    curl -sf --http1.1 -X "$method" \
       -H "Authorization: Bearer ${VERCEL_TOKEN}" \
       -H "Content-Type: application/json" \
       "$url"
@@ -721,7 +721,8 @@ trigger_redeployments() {
 
     log "  Redeploying $vercel_env ($latest_url)..."
     local new_deployment new_id
-    new_deployment="$(vercel_api "/v13/deployments/${latest_id}/redeploy" POST '{}')"
+    new_deployment="$(vercel_api "/v13/deployments" POST \
+      "$(jq -n --arg id "$latest_id" '{deploymentId: $id}')")"
     new_id="$(echo "$new_deployment" | jq -r '.id')"
     DEPLOYMENT_IDS+=("$new_id")
     log "  Queued: $new_id"

--- a/tests/bats/rotate-keys.bats
+++ b/tests/bats/rotate-keys.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$SCRIPT_DIR/scripts/rotate-keys.sh"
+
+  # Isolated temp workspace so each test gets a clean PATH and working dir.
+  # BIN_DIR is prepended to PATH so stubs shadow everything — including any
+  # system-installed vercel. Tools that ARE at system paths (/usr/bin/jq,
+  # /usr/bin/curl, /opt/homebrew/bin/gcloud) keep their stubs throughout the
+  # suite; we don't test "missing gcloud/jq/curl" because removing a BIN_DIR
+  # stub still leaves the system binary visible.
+  WORK_DIR="$(mktemp -d)"
+  BIN_DIR="$WORK_DIR/bin"
+  mkdir -p "$BIN_DIR"
+  export PATH="$BIN_DIR:$PATH"
+
+  export VERCEL_TOKEN="test-token"
+
+  # Default no-op stubs for all required tools
+  _stub vercel   'echo "rmartz"'
+  _stub gcloud   'exit 0'
+  _stub jq       'exit 0'
+  _stub curl     'exit 0'
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+# Creates a stub executable in BIN_DIR
+_stub() {
+  local name="$1"
+  local body="$2"
+  local file="$BIN_DIR/$name"
+  printf '#!/usr/bin/env bash\n%s\n' "$body" > "$file"
+  chmod +x "$file"
+}
+
+# ─── Help ─────────────────────────────────────────────────────────────────────
+
+@test "--help exits 0 and prints usage" {
+  run "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--env"* ]]
+  [[ "$output" == *"--no-invalidate"* ]]
+}
+
+@test "-h exits 0 and prints usage" {
+  run "$SCRIPT" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+# ─── Argument validation ──────────────────────────────────────────────────────
+
+@test "unknown flag exits 1 with helpful message" {
+  run "$SCRIPT" --bogus-flag
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown option"* ]]
+}
+
+@test "--env staging is accepted (alias for preview)" {
+  run "$SCRIPT" --env staging --help
+  [ "$status" -eq 0 ]
+}
+
+@test "--env preview is accepted" {
+  run "$SCRIPT" --env preview --help
+  [ "$status" -eq 0 ]
+}
+
+@test "--env production is accepted" {
+  run "$SCRIPT" --env production --help
+  [ "$status" -eq 0 ]
+}
+
+@test "--env development is accepted" {
+  run "$SCRIPT" --env development --help
+  [ "$status" -eq 0 ]
+}
+
+@test "--env all is accepted" {
+  run "$SCRIPT" --env all --help
+  [ "$status" -eq 0 ]
+}
+
+@test "--env with invalid value exits 1" {
+  run "$SCRIPT" --env bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--env must be one of"* ]]
+}
+
+@test "--env both is rejected (old alias no longer valid)" {
+  run "$SCRIPT" --env both
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--env must be one of"* ]]
+}
+
+# ─── Prerequisite checks ──────────────────────────────────────────────────────
+
+@test "exits 1 when VERCEL_TOKEN is not set" {
+  unset VERCEL_TOKEN
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VERCEL_TOKEN"* ]]
+}
+
+@test "exits 1 when vercel CLI is missing" {
+  rm -f "$BIN_DIR/vercel"
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"vercel"* ]]
+}
+
+@test "exits 1 when vercel CLI is not authenticated" {
+  _stub vercel 'exit 1'  # whoami fails
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"authenticated"* ]]
+}
+
+# ─── Project detection ────────────────────────────────────────────────────────
+
+@test "exits 1 when no project ID and no .vercel/project.json" {
+  unset VERCEL_PROJECT_ID
+
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"project ID"* ]]
+}
+
+@test "reads project ID from .vercel/project.json" {
+  mkdir -p "$WORK_DIR/.vercel"
+  printf '{"projectId":"prj_test","orgId":"team_test"}' > "$WORK_DIR/.vercel/project.json"
+
+  # Use real jq (available system-wide) for JSON parsing; curl returns no env vars
+  rm -f "$BIN_DIR/jq"
+  _stub curl 'echo "{\"envs\":[]}"'
+
+  cd "$WORK_DIR" && run "$SCRIPT"
+  # Should fail at "No Firebase or Sentry keys found" — meaning it passed project detection
+  [[ "$output" == *"No Firebase or Sentry"* ]] || [[ "$output" == *"prj_test"* ]]
+}
+
+@test "VERCEL_PROJECT_ID env var overrides project.json" {
+  export VERCEL_PROJECT_ID="prj_from_env"
+
+  rm -f "$BIN_DIR/jq"
+  _stub curl 'echo "{\"envs\":[]}"'
+
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"prj_from_env"* ]] || [[ "$output" == *"No Firebase or Sentry"* ]]
+}
+
+# ─── --no-invalidate flag ─────────────────────────────────────────────────────
+
+@test "--no-invalidate is accepted without error" {
+  run "$SCRIPT" --no-invalidate --help
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Adds `scripts/rotate-keys.sh` — a CLI tool (`rotate-keys`) that rotates Firebase service account keys and Sentry DSN keys in a Vercel project.

## What it does

1. **Auto-detects providers** from existing Vercel env var names (`FIREBASE_SERVICE_ACCOUNT` / `FIREBASE_PRIVATE_KEY` for Firebase; `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` for Sentry)
2. **Creates a distinct GCP service account key per Vercel environment** (production, preview, development), so each can be rotated independently
3. **Updates Vercel** via REST API using `jq --arg` for safe multiline encoding (handles Firebase private key newlines that break the CLI)
4. **Triggers redeployments** and waits for them to finish before invalidating anything
5. **Sweeps all non-active user-managed GCP keys** — not just the ones replaced in this run. After rotation, reads active key IDs from all three standard environments and deletes every user-managed key not in that set (catches stray/potentially leaked keys from prior partial rotations)

## Technical notes

- Supports `--env production|preview|staging|development|all` (staging is an alias for preview)
- `--no-invalidate` skips deletion (warns about old key IDs instead)
- Uses parallel arrays and indexed for-loops for bash 3.2 compatibility (macOS system bash)
- Uses `--managed-by=user` when listing/deleting GCP keys to avoid touching Google-managed keys
- Reads back from Vercel API after each write to confirm the record landed

---
*Created by Claude Sonnet 4.6*