### PR TITLE
fix: pull from development environment in generate-local-env

### DIFF
--- a/scripts/generate-local-env.sh
+++ b/scripts/generate-local-env.sh
@@ -11,4 +11,4 @@ if ! vercel whoami &>/dev/null; then
   exit 1
 fi
 
-vercel env pull .env.local --environment=preview
+vercel env pull .env.local --environment=development


### PR DESCRIPTION
Changes `generate-local-env` to pull env vars from the `development` Vercel environment instead of `preview`. This keeps local development keys isolated from the preview environment — each can be rotated independently without affecting the other.

---
*Created by Claude Sonnet 4.6*