### PR TITLE
feat(sync-env): read from Terraform deployment YAML instead of .env file

### DIFF
--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -216,7 +216,7 @@ import yaml, sys
 with open(sys.argv[1]) as f:
     data = yaml.safe_load(f) or {}
 for k, v in data.items():
-    sv = str(v) if v is not None else ''
+    sv = str(v).lower() if isinstance(v, bool) else (str(v) if v is not None else '')
     if sv:
         sys.stdout.buffer.write((str(k) + '\0' + sv + '\0').encode())
 PYEOF

--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -6,7 +6,7 @@ SCRIPT_NAME="$(basename "$0")"
 # ─── Defaults ─────────────────────────────────────────────────────────────────
 
 TARGET_ENV="all"
-ENV_FILE=".env"
+DEPLOYMENT_DIR="deployment"
 DRY_RUN=false
 
 VERCEL_API="https://api.vercel.com"
@@ -22,19 +22,20 @@ usage() {
   cat <<EOF
 Usage: $SCRIPT_NAME [OPTIONS]
 
-Upsert public (non-secret) environment variables to a Vercel project from a
-local .env file. Existing variables are updated in place; missing ones are
-created. Variables not present in the file are left untouched.
+Upsert public (non-secret) environment variables to a Vercel project from
+Terraform deployment configuration files. Reads the list of active environments
+from deployment/environments.yml and per-environment values from
+deployment/{env}.yml, using the same source of truth as Terraform.
+
+Existing variables are updated in place; missing ones are created as plain-type
+records. Variables not present in the config files are left untouched.
 
 OPTIONS:
-  --env <env>      Target Vercel environment (default: all)
-                     production   Vercel production environment
-                     preview      Vercel preview environment (alias: staging)
-                     development  Vercel development environment
-                     all          All three environments
-  --file <path>    Path to .env file to read from (default: .env)
-  --dry-run        Print what would change without making any API calls
-  -h, --help       Show this help
+  --env <name>             Target a specific environment by name as listed in
+                           environments.yml (default: all active environments)
+  --deployment-dir <path>  Path to deployment config directory (default: deployment/)
+  --dry-run                Print what would change without making any API calls
+  -h, --help               Show this help
 
 REQUIRED ENVIRONMENT VARIABLES:
   VERCEL_TOKEN       Vercel API token with project read/write access
@@ -43,15 +44,29 @@ OPTIONAL ENVIRONMENT VARIABLES:
   VERCEL_PROJECT_ID  Vercel project ID (auto-detected from .vercel/project.json)
   VERCEL_TEAM_ID     Vercel team/org ID (auto-detected from .vercel/project.json)
 
+ENVIRONMENT MAPPING (matches Terraform target_map):
+  production  → production (Vercel target)
+  staging     → preview   (Vercel target)
+  preview     → preview   (Vercel target)
+  development → development (Vercel target)
+  <other>     → passed through as-is
+
+DEPLOYMENT DIRECTORY LAYOUT:
+  deployment/
+    environments.yml   # active: [production, staging, ...]
+    production.yml     # KEY: value pairs for production
+    staging.yml        # KEY: value pairs for staging
+    ...
+
 EXAMPLES:
-  # Sync .env to all environments
+  # Sync all active environments
   sync-env
 
-  # Sync .env.production to the production environment only
-  sync-env --env production --file .env.production
+  # Sync only the staging environment
+  sync-env --env staging
 
   # Preview what would change without touching Vercel
-  sync-env --dry-run --file .env.staging
+  sync-env --dry-run
 EOF
 }
 
@@ -68,14 +83,12 @@ parse_args() {
     case "$1" in
       --env)
         TARGET_ENV="${2:-}"
-        [[ "$TARGET_ENV" =~ ^(production|preview|staging|development|all)$ ]] \
-          || err "--env must be one of: production, preview, staging, development, all"
-        [[ "$TARGET_ENV" == "staging" ]] && TARGET_ENV="preview"
+        [[ -n "$TARGET_ENV" ]] || err "--env requires an environment name or 'all'"
         shift 2
         ;;
-      --file)
-        ENV_FILE="${2:-}"
-        [[ -n "$ENV_FILE" ]] || err "--file requires a path"
+      --deployment-dir)
+        DEPLOYMENT_DIR="${2:-}"
+        [[ -n "$DEPLOYMENT_DIR" ]] || err "--deployment-dir requires a path"
         shift 2
         ;;
       --dry-run)
@@ -97,12 +110,15 @@ parse_args() {
 
 check_prereqs() {
   local missing=""
-  command -v jq   &>/dev/null || missing="${missing} jq"
-  command -v curl &>/dev/null || missing="${missing} curl"
+  command -v jq      &>/dev/null || missing="${missing} jq"
+  command -v curl    &>/dev/null || missing="${missing} curl"
+  command -v python3 &>/dev/null || missing="${missing} python3"
   [[ -n "$missing" ]] && err "Missing required tools:$missing"
 
   [[ -n "${VERCEL_TOKEN:-}" ]] || err "VERCEL_TOKEN environment variable is required"
-  [[ -f "$ENV_FILE" ]] || err "Env file not found: $ENV_FILE"
+  [[ -d "$DEPLOYMENT_DIR" ]] || err "Deployment directory not found: $DEPLOYMENT_DIR"
+  [[ -f "$DEPLOYMENT_DIR/environments.yml" ]] \
+    || err "environments.yml not found: $DEPLOYMENT_DIR/environments.yml"
 }
 
 # ─── Project detection ────────────────────────────────────────────────────────
@@ -166,35 +182,44 @@ list_env_vars() {
 
 # ─── Target resolution ────────────────────────────────────────────────────────
 
-target_envs() {
-  case "$TARGET_ENV" in
+# Maps deployment environment names to Vercel target names.
+# Matches the target_map defined in templates/terraform/main.tf.
+vercel_target() {
+  case "$1" in
     production)  echo "production" ;;
+    staging)     echo "preview" ;;
     preview)     echo "preview" ;;
     development) echo "development" ;;
-    all)         printf 'production\npreview\ndevelopment\n' ;;
+    *)           echo "$1" ;;
   esac
 }
 
-# ─── .env file parsing ────────────────────────────────────────────────────────
+# ─── Deployment config parsing ────────────────────────────────────────────────
 
-# Reads KEY=VALUE lines from a .env file, skipping comments and blank lines.
-# Strips optional surrounding single or double quotes from values.
-parse_env_file() {
-  local file="$1"
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
-    [[ "$line" == *=* ]]            || continue
-    local key="${line%%=*}"
-    local value="${line#*=}"
-    # Strip surrounding quotes only when both ends use the same quote character
-    if [[ "${value:0:1}" == '"' && "${value: -1}" == '"' ]]; then
-      value="${value:1:${#value}-2}"
-    elif [[ "${value:0:1}" == "'" && "${value: -1}" == "'" ]]; then
-      value="${value:1:${#value}-2}"
-    fi
-    printf '%s\0%s\0' "$key" "$value"
-  done < "$file"
+# Prints active environment names from environments.yml, one per line.
+list_active_envs() {
+  python3 - "${DEPLOYMENT_DIR}/environments.yml" <<'PYEOF'
+import yaml, sys
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+for env in (data.get('active') or []):
+    print(env)
+PYEOF
+}
+
+# Reads a deployment YAML file and outputs null-delimited key\0value\0 pairs.
+# Skips null and empty values, matching Terraform's `if v != null && v != ""` guard.
+# Numeric and boolean YAML values are stringified.
+parse_deployment_env() {
+  python3 - "$1" <<'PYEOF'
+import yaml, sys
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f) or {}
+for k, v in data.items():
+    sv = str(v) if v is not None else ''
+    if sv:
+        sys.stdout.buffer.write((str(k) + '\0' + sv + '\0').encode())
+PYEOF
 }
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
@@ -204,24 +229,40 @@ main() {
   check_prereqs
   detect_project
 
-  # Load key=value pairs into parallel arrays (bash 3.2 compatible)
-  local keys=() values=()
-  local key value
-  while IFS= read -r -d $'\0' key && IFS= read -r -d $'\0' value; do
-    keys+=("$key")
-    values+=("$value")
-  done < <(parse_env_file "$ENV_FILE")
+  local active_envs
+  active_envs="$(list_active_envs)"
+  [[ -n "$active_envs" ]] \
+    || err "No active environments found in ${DEPLOYMENT_DIR}/environments.yml"
 
-  local total="${#keys[@]}"
-  [[ "$total" -gt 0 ]] || err "No KEY=VALUE pairs found in $ENV_FILE"
-  log "Read $total variable(s) from $ENV_FILE"
+  local env_list
+  if [[ "$TARGET_ENV" == "all" ]]; then
+    env_list="$active_envs"
+  else
+    echo "$active_envs" | grep -qx "$TARGET_ENV" \
+      || err "--env '$TARGET_ENV' not in active environments: $(echo "$active_envs" | paste -sd ', ' -)"
+    env_list="$TARGET_ENV"
+  fi
+
+  local env_count
+  env_count="$(echo "$env_list" | grep -c .)"
 
   if [[ "$DRY_RUN" == true ]]; then
     log "Dry run — no changes will be made"
-    local i
-    for (( i = 0; i < total; i++ )); do
-      log "  Would sync: ${keys[$i]}"
-    done
+    while IFS= read -r env_name; do
+      [[ -z "$env_name" ]] && continue
+      local env_file="${DEPLOYMENT_DIR}/${env_name}.yml"
+      if [[ ! -f "$env_file" ]]; then
+        warn "No config file for '$env_name': $env_file"
+        continue
+      fi
+      local vercel_env
+      vercel_env="$(vercel_target "$env_name")"
+      log "Would sync $env_name → $vercel_env:"
+      local key value
+      while IFS= read -r -d $'\0' key && IFS= read -r -d $'\0' value; do
+        log "  Would sync: $key"
+      done < <(parse_deployment_env "$env_file")
+    done <<< "$env_list"
     return
   fi
 
@@ -230,12 +271,33 @@ main() {
 
   local total_updated=0 total_created=0
 
-  while IFS= read -r vercel_env; do
-    [[ -z "$vercel_env" ]] && continue
-    log "Syncing to $vercel_env..."
+  while IFS= read -r env_name; do
+    [[ -z "$env_name" ]] && continue
 
-    local updated=0 created=0
-    local i
+    local env_file="${DEPLOYMENT_DIR}/${env_name}.yml"
+    if [[ ! -f "$env_file" ]]; then
+      warn "No config file for '$env_name': $env_file — skipping"
+      continue
+    fi
+
+    local vercel_env
+    vercel_env="$(vercel_target "$env_name")"
+    log "Syncing $env_name → $vercel_env..."
+
+    local keys=() values=()
+    local key value
+    while IFS= read -r -d $'\0' key && IFS= read -r -d $'\0' value; do
+      keys+=("$key")
+      values+=("$value")
+    done < <(parse_deployment_env "$env_file")
+
+    local total="${#keys[@]}"
+    if [[ "$total" -eq 0 ]]; then
+      warn "No variables found in $env_file — skipping"
+      continue
+    fi
+
+    local updated=0 created=0 i
     for (( i = 0; i < total; i++ )); do
       local k="${keys[$i]}"
       local v="${values[$i]}"
@@ -264,14 +326,14 @@ main() {
       fi
     done
 
-    log "  $vercel_env — $created created, $updated updated"
+    log "  $env_name — $created created, $updated updated"
     (( total_created += created )) || true
     (( total_updated += updated )) || true
 
     # Re-fetch so subsequent environments see up-to-date state
-    [[ "$TARGET_ENV" == "all" ]] && all_envs="$(list_env_vars)"
+    [[ "$env_count" -gt 1 ]] && all_envs="$(list_env_vars)"
 
-  done < <(target_envs)
+  done <<< "$env_list"
 
   log "Done — $total_created created, $total_updated updated across all target environments."
 }

--- a/tests/bats/sync-env.bats
+++ b/tests/bats/sync-env.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$SCRIPT_DIR/scripts/sync-env.sh"
+
+  # Isolated temp workspace so each test gets a clean PATH and working dir.
+  # BIN_DIR is prepended to PATH so stubs shadow real tools as needed.
+  WORK_DIR="$(mktemp -d)"
+  BIN_DIR="$WORK_DIR/bin"
+  mkdir -p "$BIN_DIR"
+  export PATH="$BIN_DIR:$PATH"
+
+  export VERCEL_TOKEN="test-token"
+  export VERCEL_PROJECT_ID="prj_testproject"
+
+  # Create a minimal deployment/ directory with environments.yml and per-env YAMLs
+  mkdir -p "$WORK_DIR/deployment"
+  printf 'active:\n  - staging\n  - production\n' > "$WORK_DIR/deployment/environments.yml"
+  printf 'APP_ENV: staging\nPORT: 3000\n' > "$WORK_DIR/deployment/staging.yml"
+  printf 'APP_ENV: production\nDEBUG: false\n' > "$WORK_DIR/deployment/production.yml"
+
+  # Default no-op stubs for curl and jq (real system binaries still available
+  # at their system paths; these stubs shadow only the PATH lookup for tests
+  # that want to control the response).
+  _stub curl 'echo "{\"envs\":[]}"'
+  # Use real jq for JSON work — remove stub to fall through to system binary
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+# Creates a stub executable in BIN_DIR
+_stub() {
+  local name="$1"
+  local body="$2"
+  local file="$BIN_DIR/$name"
+  printf '#!/usr/bin/env bash\n%s\n' "$body" > "$file"
+  chmod +x "$file"
+}
+
+# ─── Help ─────────────────────────────────────────────────────────────────────
+
+@test "--help exits 0 and prints usage" {
+  run "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--env"* ]]
+  [[ "$output" == *"--deployment-dir"* ]]
+  [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "-h exits 0 and prints usage" {
+  run "$SCRIPT" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+# ─── Argument validation ──────────────────────────────────────────────────────
+
+@test "unknown flag exits 1 with helpful message" {
+  run "$SCRIPT" --bogus-flag
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown option"* ]]
+}
+
+@test "--env with invalid value exits 1" {
+  cd "$WORK_DIR"
+  run "$SCRIPT" --env bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bogus"* ]]
+}
+
+@test "--env with valid value from environments.yml is accepted" {
+  cd "$WORK_DIR"
+  run "$SCRIPT" --env staging --dry-run
+  [ "$status" -eq 0 ]
+}
+
+# ─── Prerequisite checks ──────────────────────────────────────────────────────
+
+@test "exits 1 when VERCEL_TOKEN is not set" {
+  unset VERCEL_TOKEN
+  cd "$WORK_DIR"
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VERCEL_TOKEN"* ]]
+}
+
+@test "exits 1 when deployment directory is missing" {
+  run "$SCRIPT" --deployment-dir "$WORK_DIR/nonexistent"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"nonexistent"* ]]
+}
+
+@test "exits 1 when environments.yml is missing" {
+  rm "$WORK_DIR/deployment/environments.yml"
+  cd "$WORK_DIR"
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"environments.yml"* ]]
+}
+
+# ─── Project detection ────────────────────────────────────────────────────────
+
+@test "exits 1 when no project ID and no .vercel/project.json" {
+  unset VERCEL_PROJECT_ID
+  cd "$WORK_DIR"
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"project ID"* ]]
+}
+
+@test "reads project ID from .vercel/project.json when env var unset" {
+  unset VERCEL_PROJECT_ID
+  mkdir -p "$WORK_DIR/.vercel"
+  printf '{"projectId":"prj_fromfile","orgId":""}' > "$WORK_DIR/.vercel/project.json"
+  cd "$WORK_DIR"
+  run "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"prj_fromfile"* ]]
+}
+
+# ─── Dry-run output ───────────────────────────────────────────────────────────
+
+@test "--dry-run prints 'Would sync' for each environment without calling curl" {
+  _stub curl 'echo "curl should not be called" >&2; exit 1'
+  cd "$WORK_DIR"
+  run "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Would sync"* ]]
+  [[ "$output" == *"staging"* ]]
+  [[ "$output" == *"production"* ]]
+}
+
+@test "--dry-run lists variable keys for each environment" {
+  _stub curl 'echo "curl should not be called" >&2; exit 1'
+  cd "$WORK_DIR"
+  run "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"APP_ENV"* ]]
+  [[ "$output" == *"PORT"* ]]
+}
+
+@test "--dry-run with --env targets only that environment" {
+  _stub curl 'echo "curl should not be called" >&2; exit 1'
+  cd "$WORK_DIR"
+  run "$SCRIPT" --dry-run --env staging
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staging"* ]]
+  [[ "$output" != *"production"* ]]
+}
+
+# ─── --deployment-dir flag ────────────────────────────────────────────────────
+
+@test "--deployment-dir uses the specified directory instead of default" {
+  local alt_dir="$WORK_DIR/alt-deploy"
+  mkdir -p "$alt_dir"
+  printf 'active:\n  - development\n' > "$alt_dir/environments.yml"
+  printf 'API_URL: http://localhost\n' > "$alt_dir/development.yml"
+
+  _stub curl 'echo "curl should not be called" >&2; exit 1'
+  run "$SCRIPT" --deployment-dir "$alt_dir" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"development"* ]]
+  [[ "$output" == *"API_URL"* ]]
+}
+
+# ─── Target mapping ───────────────────────────────────────────────────────────
+
+@test "--dry-run shows staging maps to preview target" {
+  _stub curl 'echo "curl should not be called" >&2; exit 1'
+  cd "$WORK_DIR"
+  run "$SCRIPT" --dry-run --env staging
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staging → preview"* ]]
+}
+
+@test "--dry-run shows production maps to production target" {
+  _stub curl 'echo "curl should not be called" >&2; exit 1'
+  cd "$WORK_DIR"
+  run "$SCRIPT" --dry-run --env production
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"production → production"* ]]
+}
+
+# ─── Missing per-environment config file ──────────────────────────────────────
+
+@test "warns and continues when per-env yml is missing in dry-run" {
+  rm "$WORK_DIR/deployment/production.yml"
+  _stub curl 'echo "curl should not be called" >&2; exit 1'
+  cd "$WORK_DIR"
+  run "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING"* ]]
+  [[ "$output" == *"production"* ]]
+  # staging should still have been processed
+  [[ "$output" == *"staging"* ]]
+}

--- a/tests/terraform/fixtures/staging.yml
+++ b/tests/terraform/fixtures/staging.yml
@@ -2,5 +2,6 @@ PLAIN_STRING: hello-world
 YAML_QUOTED_STRING: "5432"
 BARE_INTEGER: 12345
 QUOTED_BOOLEAN_LIKE: "true"
+BARE_BOOLEAN: true
 DATABASE_URL: "postgres://user:pass@host/db"
 EMPTY_VALUE: ""

--- a/tests/terraform/test-yaml-parsing.sh
+++ b/tests/terraform/test-yaml-parsing.sh
@@ -42,6 +42,11 @@ check(str(staging['BARE_INTEGER']) == '12345',
 check(staging['QUOTED_BOOLEAN_LIKE'] == 'true',
       "YAML-quoted '\"true\"' parses to string 'true', not bool")
 
+check(staging['BARE_BOOLEAN'] == True,
+      "Bare YAML boolean 'true' parses as Python bool True")
+check(str(staging['BARE_BOOLEAN']).lower() == 'true',
+      "str(True).lower() == 'true' (lowercased for Vercel, not 'True')")
+
 check(staging['PLAIN_STRING'] == 'hello-world',
       "Plain string parses correctly")
 


### PR DESCRIPTION
Replaces the \`.env\` file parser in \`sync-env\` with a Terraform-compatible YAML reader, so the script uses the same source of truth as the Terraform provider rather than ephemeral local files.

## What changed

- **Source**: reads \`deployment/environments.yml\` (active env list) and \`deployment/{env}.yml\` (per-environment \`KEY: value\` pairs) instead of a \`--file\` path
- **Interface**: \`--file\` is replaced by \`--deployment-dir\` (default: \`deployment/\`)
- **Target mapping**: \`staging → preview\`, \`production → production\`, \`development → development\` — matches \`target_map\` in \`templates/terraform/main.tf\`
- **\`--env\` flag**: now accepts environment names from \`environments.yml\` (e.g. \`staging\`) rather than a fixed set; validated at runtime against the active list
- **Null/empty filtering**: skips null and empty YAML values, matching Terraform's \`if v != null && v != ""\` guard
- **New prereq**: \`python3\` (for YAML parsing via PyYAML stdlib)
- **Numeric/boolean values**: stringified automatically (e.g. \`PORT: 3000\` → \`"3000"\`)

## Technical notes

Vercel API and pagination logic are unchanged. The \`vercel_target()\` function mirrors \`target_map\` from the Terraform template so environment names stay consistent across tooling.

---
*Created by Claude Sonnet 4.6*