### PR TITLE
ci: add PR title lint workflow enforcing Conventional Commits

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,27 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if printf '%s\n' "$PR_TITLE" | grep -qE '^(feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?: [^[:space:]].*$'; then
+            echo "PR title is valid: $PR_TITLE"
+          else
+            echo "PR title does not follow Conventional Commits format."
+            echo "Expected: <type>[!]: description  or  <type>(<scope>)[!]: description"
+            echo "Valid types: feat, fix, docs, chore, refactor, test, style, perf, ci, build, revert"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi


### PR DESCRIPTION
Adds a PR title validation workflow ported from hidden-role-game. Blocks merge when a PR title doesn't match the Conventional Commits pattern, preventing squash commits from landing on main with free-form messages that would break `semantic-release` version detection.

## What it does

Runs on `opened`, `edited`, `synchronize`, and `reopened` events. Validates the title against:

```
<type>[(<scope>)][!]: description
```

Valid types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `ci`, `build`, `revert`

Zero dependencies — just a `grep -E` on the title string, no third-party actions required.

---
*Created by Claude Sonnet 4.6*