### PR TITLE
fix: replace shell built-in command -v with which in commandExists

### DIFF
--- a/src/lib/subprocess.ts
+++ b/src/lib/subprocess.ts
@@ -17,6 +17,6 @@ export function run(
 }
 
 export function commandExists(cmd: string): boolean {
-  const result = spawnSync("command", ["-v", cmd], { shell: true });
+  const result = spawnSync("which", [cmd]);
   return result.status === 0;
 }


### PR DESCRIPTION
Node.js 22 emits DEP0190 when `spawnSync` is called with both `shell: true` and an args array, because the args are concatenated rather than properly escaped — the same pattern that enables shell injection.

`command -v` is a shell built-in and requires `shell: true`, but `which(1)` is a real binary available on macOS and Linux, so it can receive `cmd` as a proper argument with no shell involved.

---
*Created by Claude Sonnet 4.6*