### PR TITLE
feat!: make sync-env the sole public entrypoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       "bin": {
         "generate-local-env": "scripts/generate-local-env.sh",
         "init-terraform": "scripts/init-terraform.sh",
-        "rotate-keys": "dist/rotate-keys.js",
         "secrets-check": "scripts/secrets-check.sh",
         "sync-env": "dist/sync-env.js"
       },
@@ -767,7 +766,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1939,7 +1937,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4079,7 +4076,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -6122,7 +6118,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6817,7 +6812,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -7714,7 +7708,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7810,7 +7803,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8056,7 +8048,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8070,7 +8061,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "bin": {
     "generate-local-env": "./scripts/generate-local-env.sh",
     "init-terraform": "./scripts/init-terraform.sh",
-    "rotate-keys": "./dist/rotate-keys.js",
     "secrets-check": "./scripts/secrets-check.sh",
     "sync-env": "./dist/sync-env.js"
   },
@@ -20,7 +19,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc && chmod +x dist/sync-env.js dist/rotate-keys.js",
+    "build": "tsc && chmod +x dist/sync-env.js",
     "prepare": "npm run build",
     "test": "bats tests/bats/",
     "test:ts": "vitest run"

--- a/src/__tests__/rotate-keys.test.ts
+++ b/src/__tests__/rotate-keys.test.ts
@@ -8,7 +8,11 @@ import { parseArgs } from "../rotate-keys";
 describe("parseArgs", () => {
   it("returns defaults when no args given", () => {
     const opts = parseArgs(["node", "rotate-keys"]);
-    expect(opts).toEqual({ targetEnv: "all", invalidateKeys: true });
+    expect(opts).toEqual({
+      targetEnv: "all",
+      invalidateKeys: true,
+      init: null,
+    });
   });
 
   it("--env production sets targetEnv", () => {
@@ -39,6 +43,33 @@ describe("parseArgs", () => {
   it("--no-invalidate sets invalidateKeys to false", () => {
     const opts = parseArgs(["node", "rotate-keys", "--no-invalidate"]);
     expect(opts.invalidateKeys).toBe(false);
+  });
+
+  it("--init alone sets init to all", () => {
+    const opts = parseArgs(["node", "rotate-keys", "--init"]);
+    expect(opts.init).toBe("all");
+  });
+
+  it("--init firebase sets init to firebase", () => {
+    const opts = parseArgs(["node", "rotate-keys", "--init", "firebase"]);
+    expect(opts.init).toBe("firebase");
+  });
+
+  it("--init sentry sets init to sentry", () => {
+    const opts = parseArgs(["node", "rotate-keys", "--init", "sentry"]);
+    expect(opts.init).toBe("sentry");
+  });
+
+  it("--init followed by a non-service arg treats arg as next flag", () => {
+    const opts = parseArgs([
+      "node",
+      "rotate-keys",
+      "--init",
+      "--env",
+      "production",
+    ]);
+    expect(opts.init).toBe("all");
+    expect(opts.targetEnv).toBe("production");
   });
 
   it("throws FatalError on unknown flag", () => {
@@ -121,7 +152,7 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true }),
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
     ).rejects.toThrow(FatalError);
   });
 
@@ -133,7 +164,7 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true }),
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
     ).rejects.toThrow(FatalError);
   });
 
@@ -145,7 +176,7 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true }),
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
     ).rejects.toThrow(FatalError);
   });
 
@@ -161,10 +192,10 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true }),
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
     ).rejects.toThrow(FatalError);
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true }),
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
     ).rejects.toThrow("authenticated");
   });
 
@@ -176,7 +207,7 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true }),
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
     ).rejects.toThrow(FatalError);
   });
 
@@ -195,10 +226,147 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true }),
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
     ).rejects.toThrow(FatalError);
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true }),
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
     ).rejects.toThrow("No Firebase or Sentry");
+    await expect(
+      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+    ).rejects.toThrow("--init");
+  });
+});
+
+// ─── run — --init guard checks ────────────────────────────────────────────────
+
+describe("run — --init guard checks", () => {
+  let origEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    origEnv = { ...process.env };
+    process.env.VERCEL_TOKEN = "test-token";
+    process.env.VERCEL_PROJECT_ID = "prj_test";
+    delete process.env.VERCEL_TEAM_ID;
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+    vi.restoreAllMocks();
+  });
+
+  async function setupMocks() {
+    const subprocess = await import("../lib/subprocess");
+    vi.spyOn(subprocess, "commandExists").mockReturnValue(true);
+    vi.spyOn(subprocess, "run").mockReturnValue("rmartz");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  }
+
+  it("throws FatalError when --init firebase and Firebase keys already exist", async () => {
+    await setupMocks();
+    const { VercelClient } = await import("../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "e1",
+          key: "FIREBASE_SERVICE_ACCOUNT",
+          value: "{}",
+          target: ["production"],
+          type: "encrypted",
+        },
+      ],
+      pagination: undefined,
+    });
+
+    const { run } = await import("../rotate-keys");
+    await expect(
+      run({ targetEnv: "all", invalidateKeys: true, init: "firebase" }),
+    ).rejects.toThrow(FatalError);
+    await expect(
+      run({ targetEnv: "all", invalidateKeys: true, init: "firebase" }),
+    ).rejects.toThrow("already exist");
+  });
+
+  it("throws FatalError when --init sentry and Sentry keys already exist", async () => {
+    await setupMocks();
+    const { VercelClient } = await import("../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "e1",
+          key: "NEXT_PUBLIC_SENTRY_DSN",
+          value: "https://abc@sentry.io/1",
+          target: ["production"],
+          type: "plain",
+        },
+      ],
+      pagination: undefined,
+    });
+
+    const { run } = await import("../rotate-keys");
+    await expect(
+      run({ targetEnv: "all", invalidateKeys: true, init: "sentry" }),
+    ).rejects.toThrow(FatalError);
+    await expect(
+      run({ targetEnv: "all", invalidateKeys: true, init: "sentry" }),
+    ).rejects.toThrow("already exist");
+  });
+
+  it("throws FatalError when --init firebase and FIREBASE_SA_EMAIL is not set", async () => {
+    await setupMocks();
+    delete process.env.FIREBASE_SA_EMAIL;
+    process.env.GCLOUD_PROJECT = "my-project";
+    const { VercelClient } = await import("../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [],
+      pagination: undefined,
+    });
+
+    const { run } = await import("../rotate-keys");
+    await expect(
+      run({ targetEnv: "production", invalidateKeys: true, init: "firebase" }),
+    ).rejects.toThrow(FatalError);
+    await expect(
+      run({ targetEnv: "production", invalidateKeys: true, init: "firebase" }),
+    ).rejects.toThrow("FIREBASE_SA_EMAIL");
+  });
+
+  it("throws FatalError when --init firebase and GCLOUD_PROJECT is not set", async () => {
+    await setupMocks();
+    process.env.FIREBASE_SA_EMAIL = "sa@project.iam.gserviceaccount.com";
+    delete process.env.GCLOUD_PROJECT;
+    const { VercelClient } = await import("../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [],
+      pagination: undefined,
+    });
+
+    const { run } = await import("../rotate-keys");
+    await expect(
+      run({ targetEnv: "production", invalidateKeys: true, init: "firebase" }),
+    ).rejects.toThrow(FatalError);
+    await expect(
+      run({ targetEnv: "production", invalidateKeys: true, init: "firebase" }),
+    ).rejects.toThrow("GCLOUD_PROJECT");
+  });
+
+  it("throws FatalError when --init sentry and SENTRY_AUTH_TOKEN is not set", async () => {
+    await setupMocks();
+    delete process.env.SENTRY_AUTH_TOKEN;
+    process.env.SENTRY_ORG = "my-org";
+    process.env.SENTRY_PROJECT = "my-project";
+    const { VercelClient } = await import("../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [],
+      pagination: undefined,
+    });
+
+    const { run } = await import("../rotate-keys");
+    await expect(
+      run({ targetEnv: "production", invalidateKeys: true, init: "sentry" }),
+    ).rejects.toThrow(FatalError);
+    await expect(
+      run({ targetEnv: "production", invalidateKeys: true, init: "sentry" }),
+    ).rejects.toThrow("SENTRY_AUTH_TOKEN");
   });
 });

--- a/src/__tests__/sync-env.test.ts
+++ b/src/__tests__/sync-env.test.ts
@@ -452,6 +452,68 @@ describe("run", () => {
     expect(mockRotate).not.toHaveBeenCalled();
   });
 
+  it("forwards non-null init value to rotate-keys run", async () => {
+    const rotateKeys = await import("../rotate-keys");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(["production"], {
+      production: { MY_KEY: "val" },
+    });
+    await run({
+      targetEnv: "all",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "firebase",
+    });
+
+    expect(mockRotate).toHaveBeenCalledWith({
+      targetEnv: "all",
+      invalidateKeys: true,
+      init: "firebase",
+    });
+  });
+
+  it("dry-run logs 'Would init secrets' when init is non-null", async () => {
+    const rotateKeys = await import("../rotate-keys");
+    vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+    const mockLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(["production"], {
+      production: { MY_KEY: "val" },
+    });
+    await run({
+      targetEnv: "all",
+      deploymentDir: deployDir,
+      dryRun: true,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "sentry",
+    });
+
+    const logMessages = mockLog.mock.calls.map((c) => c[0] as string);
+    expect(logMessages.some((m) => m.includes("Would init secrets"))).toBe(true);
+    expect(logMessages.some((m) => m.includes("Would rotate keys"))).toBe(false);
+  });
+
   it("skips public var sync for development when rotateKeys is true", async () => {
     const { VercelClient } = await import("../lib/vercel-api");
     const mockListEnvVars = vi

--- a/src/__tests__/sync-env.test.ts
+++ b/src/__tests__/sync-env.test.ts
@@ -17,6 +17,7 @@ describe("parseArgs", () => {
       dryRun: false,
       rotateKeys: false,
       invalidateKeys: true,
+      init: null,
     });
   });
 
@@ -54,6 +55,36 @@ describe("parseArgs", () => {
     const opts = parseArgs(["node", "sync-env"]);
     expect(opts.rotateKeys).toBe(false);
     expect(opts.invalidateKeys).toBe(true);
+  });
+
+  it("--init alone sets init to all and implies rotateKeys", () => {
+    const opts = parseArgs(["node", "sync-env", "--init"]);
+    expect(opts.init).toBe("all");
+    expect(opts.rotateKeys).toBe(true);
+  });
+
+  it("--init firebase sets init to firebase and implies rotateKeys", () => {
+    const opts = parseArgs(["node", "sync-env", "--init", "firebase"]);
+    expect(opts.init).toBe("firebase");
+    expect(opts.rotateKeys).toBe(true);
+  });
+
+  it("--init sentry sets init to sentry and implies rotateKeys", () => {
+    const opts = parseArgs(["node", "sync-env", "--init", "sentry"]);
+    expect(opts.init).toBe("sentry");
+    expect(opts.rotateKeys).toBe(true);
+  });
+
+  it("--init followed by a non-service arg treats arg as next flag", () => {
+    const opts = parseArgs([
+      "node",
+      "sync-env",
+      "--init",
+      "--env",
+      "production",
+    ]);
+    expect(opts.init).toBe("all");
+    expect(opts.targetEnv).toBe("production");
   });
 
   it("throws FatalError on unknown flag", () => {
@@ -316,6 +347,7 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: false,
       invalidateKeys: true,
+      init: null,
     });
 
     expect(mockUpdate).toHaveBeenCalledWith("env_existing", "new_value");
@@ -350,11 +382,13 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: true,
       invalidateKeys: true,
+      init: null,
     });
 
     expect(mockRotate).toHaveBeenCalledWith({
       targetEnv: "all",
       invalidateKeys: true,
+      init: null,
     });
   });
 
@@ -387,11 +421,13 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: true,
       invalidateKeys: false,
+      init: null,
     });
 
     expect(mockRotate).toHaveBeenCalledWith({
       targetEnv: "preview",
       invalidateKeys: false,
+      init: null,
     });
   });
 
@@ -410,6 +446,7 @@ describe("run", () => {
       dryRun: true,
       rotateKeys: true,
       invalidateKeys: true,
+      init: null,
     });
 
     expect(mockRotate).not.toHaveBeenCalled();
@@ -442,6 +479,7 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: true,
       invalidateKeys: true,
+      init: null,
     });
 
     expect(mockCreateEnvVar).not.toHaveBeenCalled();
@@ -454,15 +492,13 @@ describe("run", () => {
       pagination: undefined,
     });
     vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
-    const mockCreateEnvVar = vi
-      .fn()
-      .mockResolvedValue({
-        id: "x",
-        key: "k",
-        value: "v",
-        target: [],
-        type: "plain",
-      });
+    const mockCreateEnvVar = vi.fn().mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
     vi.spyOn(VercelClient.prototype, "createEnvVar").mockImplementation(
       mockCreateEnvVar,
     );
@@ -478,6 +514,7 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: false,
       invalidateKeys: true,
+      init: null,
     });
 
     expect(mockCreateEnvVar).toHaveBeenCalledWith(
@@ -504,6 +541,7 @@ describe("run", () => {
       dryRun: true,
       rotateKeys: true,
       invalidateKeys: true,
+      init: null,
     });
 
     expect(

--- a/src/rotate-keys.ts
+++ b/src/rotate-keys.ts
@@ -11,6 +11,7 @@ import { VercelClient, VercelEnvVar } from "./lib/vercel-api";
 interface Options {
   targetEnv: string;
   invalidateKeys: boolean;
+  init: "all" | "firebase" | "sentry" | null;
 }
 
 const USAGE = `Usage: rotate-keys [OPTIONS]
@@ -29,16 +30,22 @@ Providers are auto-detected from existing Vercel env var names:
   Firebase  FIREBASE_SERVICE_ACCOUNT or FIREBASE_PRIVATE_KEY
   Sentry    SENTRY_DSN or NEXT_PUBLIC_SENTRY_DSN
 
+Use --init to push secrets into a fresh Vercel project that has none yet.
+--init fails if the target secrets already exist (use the normal rotation flow
+to update existing keys).
+
 OPTIONS:
-  --env <env>           Which Vercel environment to rotate. One of:
-                          production   Vercel production environment
-                          preview      Vercel preview environment (alias: staging)
-                          development  Vercel development environment
-                          all          All environments that already have the key
-                                       configured; unconfigured environments are
-                                       skipped (use --env <env> to explicitly add)
-  --no-invalidate       Skip deleting old keys after redeployment
-  -h, --help            Show this help
+  --env <env>                Which Vercel environment to target. One of:
+                               production   Vercel production environment
+                               preview      Vercel preview environment (alias: staging)
+                               development  Vercel development environment
+                               all          All environments (rotation: only envs that
+                                            already have the key; init: all three)
+  --init [firebase|sentry]   Bootstrap secrets into a project that has none yet.
+                               Omit the service name to init both Firebase and Sentry.
+                               Fails if the specified secrets already exist.
+  --no-invalidate            Skip deleting old keys after redeployment
+  -h, --help                 Show this help
 
 REQUIRED ENVIRONMENT VARIABLES:
   VERCEL_TOKEN          Vercel API token with project read/write access
@@ -50,10 +57,13 @@ OPTIONAL ENVIRONMENT VARIABLES:
   SENTRY_ORG            Sentry organization slug (required with Sentry rotation)
   SENTRY_PROJECT        Sentry project slug (required with Sentry rotation)
   SENTRY_URL            Sentry base URL (default: https://sentry.io)
-  GCLOUD_PROJECT        GCP project ID (auto-detected from service account JSON)`;
+  GCLOUD_PROJECT        GCP project ID (auto-detected from service account JSON)
+
+ADDITIONAL VARIABLES (required with --init firebase):
+  FIREBASE_SA_EMAIL     Service account email to create the initial GCP key for`;
 
 export function parseArgs(argv: string[]): Options {
-  const opts: Options = { targetEnv: "all", invalidateKeys: true };
+  const opts: Options = { targetEnv: "all", invalidateKeys: true, init: null };
   const args = argv.slice(2);
 
   for (let i = 0; i < args.length; i++) {
@@ -65,6 +75,14 @@ export function parseArgs(argv: string[]): Options {
       if (!valid.includes(val))
         err(`--env must be one of: ${valid.join(", ")}`);
       opts.targetEnv = val === "staging" ? "preview" : val;
+    } else if (arg === "--init") {
+      const next = args[i + 1];
+      if (next === "firebase" || next === "sentry") {
+        opts.init = next;
+        i++;
+      } else {
+        opts.init = "all";
+      }
     } else if (arg === "--no-invalidate") {
       opts.invalidateKeys = false;
     } else if (arg === "-h" || arg === "--help") {
@@ -675,6 +693,79 @@ async function invalidateSentryKey(
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
+// ─── Init (bootstrap secrets into a project that has none yet) ───────────────
+
+async function initFirebase(
+  opts: Options,
+  client: VercelClient,
+  tempDir: string,
+): Promise<void> {
+  log("Initializing Firebase service account keys...");
+
+  const saEmail = process.env.FIREBASE_SA_EMAIL;
+  if (!saEmail) err("FIREBASE_SA_EMAIL is required for --init firebase");
+  const gcpProject = process.env.GCLOUD_PROJECT;
+  if (!gcpProject) err("GCLOUD_PROJECT is required for --init firebase");
+
+  for (const vercelEnv of targetEnvs(opts.targetEnv)) {
+    const keyFile = path.join(tempDir, `key-${vercelEnv}.json`);
+    createGcpKey(keyFile, saEmail, gcpProject);
+
+    const newSaJson = JSON.parse(fs.readFileSync(keyFile, "utf-8")) as {
+      private_key_id: string;
+      [key: string]: unknown;
+    };
+    log(`  [${vercelEnv}] Created key ID: ${newSaJson.private_key_id}`);
+
+    const currentEnvs = await client.listEnvVars();
+    await client.setEnvForTarget(
+      "FIREBASE_SERVICE_ACCOUNT",
+      JSON.stringify(newSaJson),
+      vercelEnv,
+      currentEnvs.envs,
+    );
+    log(`  [${vercelEnv}] Pushed FIREBASE_SERVICE_ACCOUNT`);
+  }
+
+  log("Firebase initialization complete.");
+}
+
+async function initSentry(opts: Options, client: VercelClient): Promise<void> {
+  log("Initializing Sentry DSN...");
+
+  if (!process.env.SENTRY_AUTH_TOKEN)
+    err("SENTRY_AUTH_TOKEN is required for --init sentry");
+  if (!process.env.SENTRY_ORG) err("SENTRY_ORG is required for --init sentry");
+  if (!process.env.SENTRY_PROJECT)
+    err("SENTRY_PROJECT is required for --init sentry");
+
+  const org = process.env.SENTRY_ORG;
+  const project = process.env.SENTRY_PROJECT;
+  const dsnKeyName = "NEXT_PUBLIC_SENTRY_DSN";
+
+  log("  Creating new Sentry project key...");
+  const label = `init-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}`;
+  const newKey = await sentryRequest<SentryKey>(
+    `/projects/${org}/${project}/keys/`,
+    "POST",
+    { name: label },
+  );
+  log(`  New Sentry key ID: ${newKey.id}`);
+
+  for (const vercelEnv of targetEnvs(opts.targetEnv)) {
+    const currentEnvs = await client.listEnvVars();
+    await client.setEnvForTarget(
+      dsnKeyName,
+      newKey.dsn.public,
+      vercelEnv,
+      currentEnvs.envs,
+    );
+    log(`  [${vercelEnv}] Pushed ${dsnKeyName}`);
+  }
+
+  log("Sentry initialization complete.");
+}
+
 export async function run(opts: Options): Promise<void> {
   checkPrereqs();
 
@@ -699,60 +790,82 @@ export async function run(opts: Options): Promise<void> {
     ["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"].includes(k),
   );
 
-  if (!hasFirebase && !hasSentry) {
+  if (opts.init) {
+    if ((opts.init === "all" || opts.init === "firebase") && hasFirebase) {
+      err(
+        "Firebase keys already exist in this Vercel project — use rotate-keys to update them, not --init.",
+      );
+    }
+    if ((opts.init === "all" || opts.init === "sentry") && hasSentry) {
+      err(
+        "Sentry keys already exist in this Vercel project — use rotate-keys to update them, not --init.",
+      );
+    }
+  } else if (!hasFirebase && !hasSentry) {
     err(
-      "No Firebase or Sentry keys found in this Vercel project — nothing to rotate.",
+      "No Firebase or Sentry keys found in this Vercel project — nothing to rotate. To push secrets for the first time, use --init.",
     );
   }
 
   log(
-    `Target: ${opts.targetEnv} | Invalidate after redeployment: ${opts.invalidateKeys}`,
+    `Target: ${opts.targetEnv} | ${opts.init ? "Initializing" : `Invalidate after redeployment: ${opts.invalidateKeys}`}`,
   );
 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "rotate-keys-"));
   try {
-    let oldFirebaseKeys: OldFirebaseKey[] = [];
-    let fp: FirebasePattern | null = null;
-    let oldSentryKeyId = "";
-
-    if (hasFirebase) {
-      ({ oldKeys: oldFirebaseKeys, fp } = await rotateFirebase(
-        opts,
-        client,
-        tempDir,
-      ));
-    }
-    if (hasSentry) {
-      oldSentryKeyId = await rotateSentry(opts, client);
-    }
-
-    await triggerAndWaitRedeployments(opts, client);
-
-    if (opts.invalidateKeys) {
-      log("Invalidating old keys...");
-      if (hasFirebase && fp) await invalidateFirebaseKeys(client, fp);
-      if (hasSentry && oldSentryKeyId) {
-        await invalidateSentryKey(
-          oldSentryKeyId,
-          process.env.SENTRY_ORG!,
-          process.env.SENTRY_PROJECT!,
-        );
+    if (opts.init) {
+      if (opts.init === "all" || opts.init === "firebase") {
+        await initFirebase(opts, client, tempDir);
       }
+      if (opts.init === "all" || opts.init === "sentry") {
+        await initSentry(opts, client);
+      }
+      await triggerAndWaitRedeployments(opts, client);
+      log("Key initialization complete.");
     } else {
-      log("Skipping key invalidation (--no-invalidate)");
-      for (const { vercelEnv, keyId, saEmail } of oldFirebaseKeys) {
-        warn(
-          `Old Firebase key to remove: ${keyId} (${vercelEnv}, account: ${saEmail})`,
-        );
-      }
-      if (oldSentryKeyId) {
-        warn(
-          `Old Sentry key to remove: ${oldSentryKeyId} (project: ${process.env.SENTRY_ORG}/${process.env.SENTRY_PROJECT})`,
-        );
-      }
-    }
+      let oldFirebaseKeys: OldFirebaseKey[] = [];
+      let fp: FirebasePattern | null = null;
+      let oldSentryKeyId = "";
 
-    log("Key rotation complete.");
+      if (hasFirebase) {
+        ({ oldKeys: oldFirebaseKeys, fp } = await rotateFirebase(
+          opts,
+          client,
+          tempDir,
+        ));
+      }
+      if (hasSentry) {
+        oldSentryKeyId = await rotateSentry(opts, client);
+      }
+
+      await triggerAndWaitRedeployments(opts, client);
+
+      if (opts.invalidateKeys) {
+        log("Invalidating old keys...");
+        if (hasFirebase && fp) await invalidateFirebaseKeys(client, fp);
+        if (hasSentry && oldSentryKeyId) {
+          await invalidateSentryKey(
+            oldSentryKeyId,
+            process.env.SENTRY_ORG!,
+            process.env.SENTRY_PROJECT!,
+          );
+        }
+      } else {
+        log("Skipping key invalidation (--no-invalidate)");
+        for (const { vercelEnv, keyId, saEmail } of oldFirebaseKeys) {
+          warn(
+            `Old Firebase key to remove: ${keyId} (${vercelEnv}, account: ${saEmail})`,
+          );
+        }
+        if (oldSentryKeyId) {
+          warn(
+            `Old Sentry key to remove: ${oldSentryKeyId} (project: ${process.env.SENTRY_ORG}/${process.env.SENTRY_PROJECT})`,
+          );
+        }
+      }
+
+      log("Key rotation complete.");
+    }
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/src/rotate-keys.ts
+++ b/src/rotate-keys.ts
@@ -60,7 +60,9 @@ OPTIONAL ENVIRONMENT VARIABLES:
   GCLOUD_PROJECT        GCP project ID (auto-detected from service account JSON)
 
 ADDITIONAL VARIABLES (required with --init firebase):
-  FIREBASE_SA_EMAIL     Service account email to create the initial GCP key for`;
+  GCLOUD_PROJECT        GCP project ID (required for --init firebase; auto-detected
+                        from service account JSON during normal rotation)
+  FIREBASE_SA_EMAIL     Service account email for which the initial GCP key will be created`;
 
 export function parseArgs(argv: string[]): Options {
   const opts: Options = { targetEnv: "all", invalidateKeys: true, init: null };
@@ -103,10 +105,10 @@ function targetEnvs(targetEnv: string): string[] {
 
 // ─── Prerequisites ────────────────────────────────────────────────────────────
 
-function checkPrereqs(): void {
+function checkPrereqs(needsGcloud: boolean): void {
   const missing: string[] = [];
   if (!commandExists("vercel")) missing.push("vercel");
-  if (!commandExists("gcloud")) missing.push("gcloud");
+  if (needsGcloud && !commandExists("gcloud")) missing.push("gcloud");
   if (missing.length > 0) err(`Missing required tools: ${missing.join(" ")}`);
 
   if (!process.env.VERCEL_TOKEN)
@@ -767,7 +769,11 @@ async function initSentry(opts: Options, client: VercelClient): Promise<void> {
 }
 
 export async function run(opts: Options): Promise<void> {
-  checkPrereqs();
+  // gcloud is only needed for Firebase-related flows.
+  // When opts.init === null we don't yet know hasFirebase, so we conservatively
+  // require gcloud unless we know this is a Sentry-only init.
+  const needsGcloud = opts.init !== "sentry";
+  checkPrereqs(needsGcloud);
 
   const project = detectProject();
   log(
@@ -793,12 +799,12 @@ export async function run(opts: Options): Promise<void> {
   if (opts.init) {
     if ((opts.init === "all" || opts.init === "firebase") && hasFirebase) {
       err(
-        "Firebase keys already exist in this Vercel project — use rotate-keys to update them, not --init.",
+        "Firebase keys already exist in this Vercel project — use sync-env --rotate-keys to update them, not --init.",
       );
     }
     if ((opts.init === "all" || opts.init === "sentry") && hasSentry) {
       err(
-        "Sentry keys already exist in this Vercel project — use rotate-keys to update them, not --init.",
+        "Sentry keys already exist in this Vercel project — use sync-env --rotate-keys to update them, not --init.",
       );
     }
   } else if (!hasFirebase && !hasSentry) {

--- a/src/rotate-keys.ts
+++ b/src/rotate-keys.ts
@@ -709,7 +709,7 @@ async function initFirebase(
 
   for (const vercelEnv of targetEnvs(opts.targetEnv)) {
     const keyFile = path.join(tempDir, `key-${vercelEnv}.json`);
-    createGcpKey(keyFile, saEmail, gcpProject);
+    createGcpKey(keyFile, saEmail!, gcpProject!);
 
     const newSaJson = JSON.parse(fs.readFileSync(keyFile, "utf-8")) as {
       private_key_id: string;

--- a/src/sync-env.ts
+++ b/src/sync-env.ts
@@ -18,6 +18,7 @@ interface Options {
   dryRun: boolean;
   rotateKeys: boolean;
   invalidateKeys: boolean;
+  init: "all" | "firebase" | "sentry" | null;
 }
 
 const USAGE = `Usage: sync-env [OPTIONS]
@@ -38,6 +39,9 @@ OPTIONS:
                            environments.yml (default: all active environments)
   --deployment-dir <path>  Path to deployment config directory (default: deployment/)
   --rotate-keys            Also rotate Firebase/Sentry secrets and redeploy
+  --init [firebase|sentry] Bootstrap initial secrets for a fresh project (implies
+                           --rotate-keys). Accepts firebase, sentry, or omit for
+                           both. Fails if the chosen secrets already exist.
   --no-invalidate          (with --rotate-keys) Skip deleting old keys after
                            redeployment
   --dry-run                Print what would change without making any API calls
@@ -54,7 +58,9 @@ ADDITIONAL VARIABLES (required with --rotate-keys):
   SENTRY_AUTH_TOKEN  Sentry API token (required when Sentry DSN is present)
   SENTRY_ORG         Sentry organization slug (required with Sentry rotation)
   SENTRY_PROJECT     Sentry project slug (required with Sentry rotation)
-  GCLOUD_PROJECT     GCP project ID (auto-detected from service account JSON)
+  GCLOUD_PROJECT     GCP project ID (required with --init firebase; auto-detected
+                     from service account JSON during rotation)
+  FIREBASE_SA_EMAIL  Firebase service account email (required with --init firebase)
 
 ENVIRONMENT MAPPING (matches Terraform target_map):
   production  → production (Vercel target)
@@ -96,6 +102,7 @@ export function parseArgs(argv: string[]): Options {
     dryRun: false,
     rotateKeys: false,
     invalidateKeys: true,
+    init: null,
   };
   const args = argv.slice(2);
 
@@ -111,6 +118,15 @@ export function parseArgs(argv: string[]): Options {
     } else if (arg === "--dry-run") {
       opts.dryRun = true;
     } else if (arg === "--rotate-keys") {
+      opts.rotateKeys = true;
+    } else if (arg === "--init") {
+      const next = args[i + 1];
+      if (next === "firebase" || next === "sentry") {
+        opts.init = next;
+        i++;
+      } else {
+        opts.init = "all";
+      }
       opts.rotateKeys = true;
     } else if (arg === "--no-invalidate") {
       opts.invalidateKeys = false;
@@ -181,7 +197,12 @@ export async function run(opts: Options): Promise<void> {
         log(`  Would sync: ${key}`);
       }
     }
-    if (opts.rotateKeys) log("Would rotate keys (skipped in dry-run)");
+    if (opts.rotateKeys)
+      log(
+        opts.init
+          ? "Would init secrets (skipped in dry-run)"
+          : "Would rotate keys (skipped in dry-run)",
+      );
     return;
   }
 
@@ -253,6 +274,7 @@ export async function run(opts: Options): Promise<void> {
     await rotateKeysRun({
       targetEnv: rotateTarget,
       invalidateKeys: opts.invalidateKeys,
+      init: opts.init,
     });
   }
 }


### PR DESCRIPTION
Remove `rotate-keys` from the package `bin` so it is no longer installed as a standalone CLI command. All functionality is now reachable through `sync-env`:

- `sync-env --rotate-keys` — rotate existing Firebase / Sentry secrets
- `sync-env --init [firebase|sentry]` — bootstrap first-time secrets (implies `--rotate-keys`)

Includes the `--init` implementation cherry-picked from #31, which this PR supersedes.

**Technical notes**: Dropped `dist/rotate-keys.js` from the `chmod +x` build step. The `rotate-keys` module remains importable internally by `sync-env` at runtime.

---
*Created by Claude Sonnet 4.6*