### PR TITLE
fix: support feat!: breaking change syntax in semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,22 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "parserOpts": {
+          "breakingHeaderPattern": "^(\\w*)(?:\\(([\\w$\\.\\-\\*\\/@ ]*)\\))?!: (.*)$"
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "parserOpts": {
+          "breakingHeaderPattern": "^(\\w*)(?:\\(([\\w$\\.\\-\\*\\/@ ]*)\\))?!: (.*)$"
+        }
+      }
+    ],
     ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     [
       "@semantic-release/git",


### PR DESCRIPTION
`@semantic-release/commit-analyzer` detects breaking changes by checking `commit.notes.length > 0`. The `feat!:` shorthand (Conventional Commits v1.0.0) does not populate `notes` by default — only an explicit `BREAKING CHANGE:` footer entry does. The `feat!: make sync-env the sole public entrypoint` commit that just merged was analyzed as a `feat` → minor, not major.

Setting `breakingHeaderPattern` in `parserOpts` causes `conventional-commits-parser` to inject a synthetic breaking-change note when the header matches `!:`, which propagates through to a major version bump. The pattern is set on both `commit-analyzer` and `release-notes-generator` so the breaking change appears in the generated changelog entry as well.

When this PR merges, semantic-release will re-analyze commits since v1.8.0, find `feat!: make sync-env the sole public entrypoint (#32)` as MAJOR, and publish v2.0.0.

---
*Created by Claude Sonnet 4.6*