### PR TITLE
feat: read Firebase/Sentry config from deployment YAML in sync-env

### DIFF
--- a/src/__tests__/sync-env-tests/run-rotate.test.ts
+++ b/src/__tests__/sync-env-tests/run-rotate.test.ts
@@ -121,7 +121,7 @@ describe("run", () => {
     expect(mockRotate).not.toHaveBeenCalled();
   });
 
-  it("forwards non-null init value to rotate-keys run", async () => {
+  it("forwards non-null init value to rotate-keys run for a specific env", async () => {
     const rotateKeys = await import("../../rotate-keys");
     const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
 
@@ -142,7 +142,61 @@ describe("run", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     const deployDir = makeDeploymentDir(tmpDir, ["production"], {
-      production: { MY_KEY: "val" },
+      production: {
+        MY_KEY: "val",
+        FIREBASE_SA_EMAIL: "sa@my-project.iam.gserviceaccount.com",
+        FIREBASE_PROJECT_ID: "my-project",
+      },
+    });
+    await run({
+      targetEnv: "production",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "firebase",
+    });
+
+    expect(mockRotate).toHaveBeenCalledWith({
+      targetEnv: "production",
+      invalidateKeys: true,
+      init: "firebase",
+      firebaseSaEmail: "sa@my-project.iam.gserviceaccount.com",
+      gcpProject: "my-project",
+    });
+  });
+
+  it("--init --env all iterates once per deployment env with per-env YAML values", async () => {
+    const rotateKeys = await import("../../rotate-keys");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["production", "staging"], {
+      production: {
+        MY_KEY: "prod-val",
+        FIREBASE_SA_EMAIL: "sa@prod.iam.gserviceaccount.com",
+        FIREBASE_PROJECT_ID: "my-prod",
+      },
+      staging: {
+        MY_KEY: "staging-val",
+        FIREBASE_SA_EMAIL: "sa@staging.iam.gserviceaccount.com",
+        FIREBASE_PROJECT_ID: "my-staging",
+      },
     });
     await run({
       targetEnv: "all",
@@ -153,10 +207,140 @@ describe("run", () => {
       init: "firebase",
     });
 
+    expect(mockRotate).toHaveBeenCalledTimes(2);
+    expect(mockRotate).toHaveBeenCalledWith({
+      targetEnv: "production",
+      invalidateKeys: true,
+      init: "firebase",
+      firebaseSaEmail: "sa@prod.iam.gserviceaccount.com",
+      gcpProject: "my-prod",
+    });
+    expect(mockRotate).toHaveBeenCalledWith({
+      targetEnv: "preview",
+      invalidateKeys: true,
+      init: "firebase",
+      firebaseSaEmail: "sa@staging.iam.gserviceaccount.com",
+      gcpProject: "my-staging",
+    });
+  });
+
+  it("--init sentry --env all calls rotate once with targetEnv all", async () => {
+    const rotateKeys = await import("../../rotate-keys");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["production", "staging"], {
+      production: {
+        MY_KEY: "pval",
+        SENTRY_ORG: "my-org",
+        SENTRY_PROJECT: "my-proj",
+      },
+      staging: {
+        MY_KEY: "sval",
+        SENTRY_ORG: "my-org",
+        SENTRY_PROJECT: "my-proj",
+      },
+    });
+    await run({
+      targetEnv: "all",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "sentry",
+    });
+
+    expect(mockRotate).toHaveBeenCalledTimes(1);
     expect(mockRotate).toHaveBeenCalledWith({
       targetEnv: "all",
       invalidateKeys: true,
+      init: "sentry",
+      sentryOrg: "my-org",
+      sentryProject: "my-proj",
+    });
+  });
+
+  it("--init all --env all calls Sentry once and Firebase per deployment env", async () => {
+    const rotateKeys = await import("../../rotate-keys");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["production", "staging"], {
+      production: {
+        MY_KEY: "pval",
+        SENTRY_ORG: "my-org",
+        SENTRY_PROJECT: "my-proj",
+        FIREBASE_SA_EMAIL: "sa@prod.iam.gserviceaccount.com",
+        FIREBASE_PROJECT_ID: "my-prod",
+      },
+      staging: {
+        MY_KEY: "sval",
+        SENTRY_ORG: "my-org",
+        SENTRY_PROJECT: "my-proj",
+        FIREBASE_SA_EMAIL: "sa@staging.iam.gserviceaccount.com",
+        FIREBASE_PROJECT_ID: "my-staging",
+      },
+    });
+    await run({
+      targetEnv: "all",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "all",
+    });
+
+    expect(mockRotate).toHaveBeenCalledTimes(3);
+    expect(mockRotate).toHaveBeenNthCalledWith(1, {
+      targetEnv: "all",
+      invalidateKeys: true,
+      init: "sentry",
+      sentryOrg: "my-org",
+      sentryProject: "my-proj",
+    });
+    expect(mockRotate).toHaveBeenNthCalledWith(2, {
+      targetEnv: "production",
+      invalidateKeys: true,
       init: "firebase",
+      firebaseSaEmail: "sa@prod.iam.gserviceaccount.com",
+      gcpProject: "my-prod",
+    });
+    expect(mockRotate).toHaveBeenNthCalledWith(3, {
+      targetEnv: "preview",
+      invalidateKeys: true,
+      init: "firebase",
+      firebaseSaEmail: "sa@staging.iam.gserviceaccount.com",
+      gcpProject: "my-staging",
     });
   });
 

--- a/src/rotate-keys.ts
+++ b/src/rotate-keys.ts
@@ -12,6 +12,14 @@ interface Options {
   targetEnv: string;
   invalidateKeys: boolean;
   init?: "all" | "firebase" | "sentry";
+  /** SA email for --init firebase. Falls back to FIREBASE_SA_EMAIL env var. */
+  firebaseSaEmail?: string;
+  /** GCP project ID for --init firebase. Falls back to GCLOUD_PROJECT env var. */
+  gcpProject?: string;
+  /** Sentry org slug. Falls back to SENTRY_ORG env var. */
+  sentryOrg?: string;
+  /** Sentry project slug. Falls back to SENTRY_PROJECT env var. */
+  sentryProject?: string;
 }
 
 const USAGE = `Usage: rotate-keys [OPTIONS]
@@ -61,10 +69,14 @@ OPTIONAL ENVIRONMENT VARIABLES:
                         from service account JSON during normal rotation)
 
 ADDITIONAL VARIABLES (required with --init firebase):
-  GCLOUD_PROJECT        GCP project ID (required for --init firebase; auto-detected
-                        from service account JSON during normal rotation)
+  GCLOUD_PROJECT        GCP project ID — read from FIREBASE_PROJECT_ID in deployment
+                        YAML when invoked via sync-env; falls back to GCLOUD_PROJECT
+                        shell env var; auto-detected from service account JSON during
+                        normal rotation
   FIREBASE_SA_EMAIL     Service account email for which the initial GCP key will be
-                        created (e.g. my-sa@my-project.iam.gserviceaccount.com)`;
+                        created — read from deployment YAML when invoked via sync-env;
+                        falls back to FIREBASE_SA_EMAIL shell env var
+                        (e.g. my-sa@my-project.iam.gserviceaccount.com)`;
 
 export function parseArgs(argv: string[]): Options {
   const opts: Options = { targetEnv: "all", invalidateKeys: true };
@@ -474,13 +486,10 @@ async function rotateSentry(
 
   if (!process.env.SENTRY_AUTH_TOKEN)
     err("SENTRY_AUTH_TOKEN is required for Sentry rotation");
-  if (!process.env.SENTRY_ORG)
-    err("SENTRY_ORG is required for Sentry rotation");
-  if (!process.env.SENTRY_PROJECT)
-    err("SENTRY_PROJECT is required for Sentry rotation");
-
-  const org = process.env.SENTRY_ORG;
-  const project = process.env.SENTRY_PROJECT;
+  const org = opts.sentryOrg ?? process.env.SENTRY_ORG;
+  if (!org) err("SENTRY_ORG is required for Sentry rotation");
+  const project = opts.sentryProject ?? process.env.SENTRY_PROJECT;
+  if (!project) err("SENTRY_PROJECT is required for Sentry rotation");
 
   const allEnvs = await client.listEnvVars();
   let dsnKeyName = "";
@@ -699,9 +708,9 @@ async function initFirebase(
 ): Promise<void> {
   log("Initializing Firebase service account keys...");
 
-  const saEmail = process.env.FIREBASE_SA_EMAIL;
+  const saEmail = opts.firebaseSaEmail ?? process.env.FIREBASE_SA_EMAIL;
   if (!saEmail) err("FIREBASE_SA_EMAIL is required for --init firebase");
-  const gcpProject = process.env.GCLOUD_PROJECT;
+  const gcpProject = opts.gcpProject ?? process.env.GCLOUD_PROJECT;
   if (!gcpProject) err("GCLOUD_PROJECT is required for --init firebase");
 
   const currentEnvs = await client.listEnvVars();
@@ -731,12 +740,10 @@ async function initSentry(opts: Options, client: VercelClient): Promise<void> {
 
   if (!process.env.SENTRY_AUTH_TOKEN)
     err("SENTRY_AUTH_TOKEN is required for --init sentry");
-  if (!process.env.SENTRY_ORG) err("SENTRY_ORG is required for --init sentry");
-  if (!process.env.SENTRY_PROJECT)
-    err("SENTRY_PROJECT is required for --init sentry");
-
-  const org = process.env.SENTRY_ORG;
-  const project = process.env.SENTRY_PROJECT;
+  const org = opts.sentryOrg ?? process.env.SENTRY_ORG;
+  if (!org) err("SENTRY_ORG is required for --init sentry");
+  const project = opts.sentryProject ?? process.env.SENTRY_PROJECT;
+  if (!project) err("SENTRY_PROJECT is required for --init sentry");
   const dsnKeyName = "NEXT_PUBLIC_SENTRY_DSN";
 
   log("  Creating new Sentry project key...");
@@ -846,8 +853,8 @@ export async function run(opts: Options): Promise<void> {
         if (hasSentry && oldSentryKeyId) {
           await invalidateSentryKey(
             oldSentryKeyId,
-            process.env.SENTRY_ORG!,
-            process.env.SENTRY_PROJECT!,
+            (opts.sentryOrg ?? process.env.SENTRY_ORG)!,
+            (opts.sentryProject ?? process.env.SENTRY_PROJECT)!,
           );
         }
       } else {

--- a/src/sync-env.ts
+++ b/src/sync-env.ts
@@ -55,12 +55,21 @@ OPTIONAL ENVIRONMENT VARIABLES:
   VERCEL_TEAM_ID     Vercel team/org ID (auto-detected from .vercel/project.json)
 
 ADDITIONAL VARIABLES (required with --rotate-keys):
-  SENTRY_AUTH_TOKEN  Sentry API token (required when Sentry DSN is present)
-  SENTRY_ORG         Sentry organization slug (required with Sentry rotation)
-  SENTRY_PROJECT     Sentry project slug (required with Sentry rotation)
-  GCLOUD_PROJECT     GCP project ID (required with --init firebase; auto-detected
-                     from service account JSON during rotation)
-  FIREBASE_SA_EMAIL  Firebase service account email (required with --init firebase)
+  SENTRY_AUTH_TOKEN  Sentry API token with project read/write access (required
+                     when Sentry DSN is present; must be set in shell environment)
+
+The following are read automatically from the deployment YAML when available
+(SENTRY_ORG, SENTRY_PROJECT, FIREBASE_PROJECT_ID, FIREBASE_SA_EMAIL keys).
+Shell environment variables are used as a fallback if the YAML key is absent
+or empty.
+
+  SENTRY_ORG         Sentry organization slug (SENTRY_ORG in YAML or shell)
+  SENTRY_PROJECT     Sentry project slug (SENTRY_PROJECT in YAML or shell)
+  GCLOUD_PROJECT     GCP project ID for --init firebase (FIREBASE_PROJECT_ID in
+                     YAML or GCLOUD_PROJECT in shell; auto-detected from service
+                     account JSON during normal rotation)
+  FIREBASE_SA_EMAIL  Firebase service account email for --init firebase
+                     (FIREBASE_SA_EMAIL in YAML or shell)
 
 ENVIRONMENT MAPPING (matches Terraform target_map):
   production  → production (Vercel target)
@@ -269,13 +278,43 @@ export async function run(opts: Options): Promise<void> {
   );
 
   if (opts.rotateKeys) {
-    const rotateTarget =
-      opts.targetEnv === "all" ? "all" : vercelTarget(opts.targetEnv);
-    await rotateKeysRun({
-      targetEnv: rotateTarget,
-      invalidateKeys: opts.invalidateKeys,
-      init: opts.init,
-    });
+    if (opts.init && opts.targetEnv === "all") {
+      // --init with all envs: each deployment env has its own Firebase project
+      // and SA email, so rotate once per env with that env's YAML values.
+      // Development is skipped (no remote deployment target).
+      for (const envName of envList) {
+        if (envName === "development") continue;
+        const envVars = parseDeploymentEnv(opts.deploymentDir, envName);
+        await rotateKeysRun({
+          targetEnv: vercelTarget(envName),
+          invalidateKeys: opts.invalidateKeys,
+          init: opts.init,
+          firebaseSaEmail: envVars.FIREBASE_SA_EMAIL || undefined,
+          gcpProject: envVars.FIREBASE_PROJECT_ID || undefined,
+          sentryOrg: envVars.SENTRY_ORG || undefined,
+          sentryProject: envVars.SENTRY_PROJECT || undefined,
+        });
+      }
+    } else {
+      // Single-env or rotation-only: one call. For --env all, read YAML values
+      // from the first active env (Sentry org/project are the same across envs;
+      // Firebase credentials are auto-detected from existing keys during rotation).
+      const sourceEnv = opts.targetEnv === "all" ? envList[0] : opts.targetEnv;
+      const envVars = sourceEnv
+        ? parseDeploymentEnv(opts.deploymentDir, sourceEnv)
+        : {};
+      const rotateTarget =
+        opts.targetEnv === "all" ? "all" : vercelTarget(opts.targetEnv);
+      await rotateKeysRun({
+        targetEnv: rotateTarget,
+        invalidateKeys: opts.invalidateKeys,
+        init: opts.init,
+        firebaseSaEmail: envVars.FIREBASE_SA_EMAIL || undefined,
+        gcpProject: envVars.FIREBASE_PROJECT_ID || undefined,
+        sentryOrg: envVars.SENTRY_ORG || undefined,
+        sentryProject: envVars.SENTRY_PROJECT || undefined,
+      });
+    }
   }
 }
 

--- a/src/sync-env.ts
+++ b/src/sync-env.ts
@@ -279,21 +279,36 @@ export async function run(opts: Options): Promise<void> {
 
   if (opts.rotateKeys) {
     if (opts.init && opts.targetEnv === "all") {
-      // --init with all envs: each deployment env has its own Firebase project
-      // and SA email, so rotate once per env with that env's YAML values.
-      // Development is skipped (no remote deployment target).
-      for (const envName of envList) {
-        if (envName === "development") continue;
-        const envVars = parseDeploymentEnv(opts.deploymentDir, envName);
+      const nonDevEnvs = envList.filter((e) => e !== "development");
+      // Sentry is project-level (one org/project): init once across all Vercel
+      // targets so only one key is created and stored in every environment.
+      if (
+        (opts.init === "sentry" || opts.init === "all") &&
+        nonDevEnvs.length > 0
+      ) {
+        const firstEnv = nonDevEnvs[0];
+        const envVars = parseDeploymentEnv(opts.deploymentDir, firstEnv);
         await rotateKeysRun({
-          targetEnv: vercelTarget(envName),
+          targetEnv: "all",
           invalidateKeys: opts.invalidateKeys,
-          init: opts.init,
-          firebaseSaEmail: envVars.FIREBASE_SA_EMAIL || undefined,
-          gcpProject: envVars.FIREBASE_PROJECT_ID || undefined,
+          init: "sentry",
           sentryOrg: envVars.SENTRY_ORG || undefined,
           sentryProject: envVars.SENTRY_PROJECT || undefined,
         });
+      }
+      // Firebase is per-project: each deployment env has its own Firebase project
+      // and SA email, so init once per env with that env's YAML values.
+      if (opts.init === "firebase" || opts.init === "all") {
+        for (const envName of nonDevEnvs) {
+          const envVars = parseDeploymentEnv(opts.deploymentDir, envName);
+          await rotateKeysRun({
+            targetEnv: vercelTarget(envName),
+            invalidateKeys: opts.invalidateKeys,
+            init: "firebase",
+            firebaseSaEmail: envVars.FIREBASE_SA_EMAIL || undefined,
+            gcpProject: envVars.FIREBASE_PROJECT_ID || undefined,
+          });
+        }
       }
     } else {
       // Single-env or rotation-only: one call. For --env all, read YAML values


### PR DESCRIPTION
`rotate-keys` previously required `FIREBASE_SA_EMAIL`, `GCLOUD_PROJECT`, `SENTRY_ORG`, and `SENTRY_PROJECT` to be set as shell environment variables even though `sync-env` had already parsed equivalent values from the deployment YAML. Users had to repeat non-sensitive config in two places.

## What changed

`sync-env` now extracts these values from the deployment YAML and passes them to `rotateKeysRun` as options fields. `rotate-keys` uses the passed value with a `??` fallback to the shell environment variable, preserving backwards compatibility when `rotate-keys` is invoked directly.

| YAML key | Was required in shell | Now read from |
|---|---|---|
| `FIREBASE_SA_EMAIL` | `FIREBASE_SA_EMAIL` | YAML, fallback to shell |
| `FIREBASE_PROJECT_ID` | `GCLOUD_PROJECT` | YAML, fallback to shell |
| `SENTRY_ORG` | `SENTRY_ORG` | YAML, fallback to shell |
| `SENTRY_PROJECT` | `SENTRY_PROJECT` | YAML, fallback to shell |

Secrets that must remain in the shell environment: `VERCEL_TOKEN`, `SENTRY_AUTH_TOKEN`.

**`--init --env all` behaviour change**: previously called `rotate-keys` once with `targetEnv: "all"`, applying a single SA to all Vercel environments. Now calls once per active deployment env (skipping development), so production and staging each use their own Firebase project SA and GCP project — the correct behaviour when they point to separate Firebase projects.

---
*Created by Claude Sonnet 4.6*