### PR TITLE
chore: replace null with undefined for Options.init and fp

### DIFF
--- a/src/__tests__/rotate-keys-tests/parse-args.test.ts
+++ b/src/__tests__/rotate-keys-tests/parse-args.test.ts
@@ -11,7 +11,7 @@ describe("parseArgs", () => {
     expect(opts).toEqual({
       targetEnv: "all",
       invalidateKeys: true,
-      init: null,
+      init: undefined,
     });
   });
 

--- a/src/__tests__/rotate-keys-tests/prereqs.test.ts
+++ b/src/__tests__/rotate-keys-tests/prereqs.test.ts
@@ -27,7 +27,7 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow(FatalError);
   });
 
@@ -39,7 +39,7 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow(FatalError);
   });
 
@@ -51,7 +51,7 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow(FatalError);
   });
 
@@ -67,10 +67,10 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow(FatalError);
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow("authenticated");
   });
 
@@ -82,7 +82,7 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow(FatalError);
   });
 
@@ -101,13 +101,13 @@ describe("run — prerequisite checks", () => {
 
     const { run } = await import("../../rotate-keys");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow(FatalError);
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow("No Firebase or Sentry");
     await expect(
-      run({ targetEnv: "all", invalidateKeys: true, init: null }),
+      run({ targetEnv: "all", invalidateKeys: true }),
     ).rejects.toThrow("--init");
   });
 });

--- a/src/__tests__/sync-env-tests/parse-args.test.ts
+++ b/src/__tests__/sync-env-tests/parse-args.test.ts
@@ -14,7 +14,7 @@ describe("parseArgs", () => {
       dryRun: false,
       rotateKeys: false,
       invalidateKeys: true,
-      init: null,
+      init: undefined,
     });
   });
 

--- a/src/__tests__/sync-env-tests/run-api.test.ts
+++ b/src/__tests__/sync-env-tests/run-api.test.ts
@@ -101,7 +101,7 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: false,
       invalidateKeys: true,
-      init: null,
+      init: undefined,
     });
 
     expect(mockUpdate).toHaveBeenCalledWith("env_existing", "new_value");

--- a/src/__tests__/sync-env-tests/run-development.test.ts
+++ b/src/__tests__/sync-env-tests/run-development.test.ts
@@ -54,7 +54,6 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: true,
       invalidateKeys: true,
-      init: null,
     });
 
     expect(mockCreateEnvVar).not.toHaveBeenCalled();
@@ -89,7 +88,6 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: false,
       invalidateKeys: true,
-      init: null,
     });
 
     expect(mockCreateEnvVar).toHaveBeenCalledWith(
@@ -116,7 +114,6 @@ describe("run", () => {
       dryRun: true,
       rotateKeys: true,
       invalidateKeys: true,
-      init: null,
     });
 
     expect(

--- a/src/__tests__/sync-env-tests/run-rotate.test.ts
+++ b/src/__tests__/sync-env-tests/run-rotate.test.ts
@@ -56,13 +56,11 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: true,
       invalidateKeys: true,
-      init: null,
     });
 
     expect(mockRotate).toHaveBeenCalledWith({
       targetEnv: "all",
       invalidateKeys: true,
-      init: null,
     });
   });
 
@@ -95,13 +93,11 @@ describe("run", () => {
       dryRun: false,
       rotateKeys: true,
       invalidateKeys: false,
-      init: null,
     });
 
     expect(mockRotate).toHaveBeenCalledWith({
       targetEnv: "preview",
       invalidateKeys: false,
-      init: null,
     });
   });
 
@@ -120,7 +116,6 @@ describe("run", () => {
       dryRun: true,
       rotateKeys: true,
       invalidateKeys: true,
-      init: null,
     });
 
     expect(mockRotate).not.toHaveBeenCalled();

--- a/src/rotate-keys.ts
+++ b/src/rotate-keys.ts
@@ -11,7 +11,7 @@ import { VercelClient, VercelEnvVar } from "./lib/vercel-api";
 interface Options {
   targetEnv: string;
   invalidateKeys: boolean;
-  init: "all" | "firebase" | "sentry" | null;
+  init?: "all" | "firebase" | "sentry";
 }
 
 const USAGE = `Usage: rotate-keys [OPTIONS]
@@ -67,7 +67,7 @@ ADDITIONAL VARIABLES (required with --init firebase):
                         created (e.g. my-sa@my-project.iam.gserviceaccount.com)`;
 
 export function parseArgs(argv: string[]): Options {
-  const opts: Options = { targetEnv: "all", invalidateKeys: true, init: null };
+  const opts: Options = { targetEnv: "all", invalidateKeys: true };
   const args = argv.slice(2);
 
   for (let i = 0; i < args.length; i++) {
@@ -261,13 +261,13 @@ async function getFirebaseSaForEnv(
   envs: VercelEnvVar[],
   pattern: "json" | "split",
   client: VercelClient,
-): Promise<FirebaseSaInfo | null> {
+): Promise<FirebaseSaInfo | undefined> {
   if (pattern === "json") {
     const record = envs.find(
       (e) =>
         e.key === "FIREBASE_SERVICE_ACCOUNT" && e.target.includes(vercelEnv),
     );
-    if (!record) return null;
+    if (!record) return undefined;
     const saJson = JSON.parse(await client.getEnvVarValue(record.id)) as {
       client_email: string;
       project_id: string;
@@ -278,7 +278,7 @@ async function getFirebaseSaForEnv(
   const ceRecord = envs.find(
     (e) => e.key === "FIREBASE_CLIENT_EMAIL" && e.target.includes(vercelEnv),
   );
-  if (!ceRecord) return null;
+  if (!ceRecord) return undefined;
   const email = await client.getEnvVarValue(ceRecord.id);
 
   let gcpProject = "";
@@ -771,7 +771,7 @@ async function initSentry(opts: Options, client: VercelClient): Promise<void> {
 
 export async function run(opts: Options): Promise<void> {
   // gcloud is only needed for Firebase-related flows.
-  // When opts.init === null we don't yet know hasFirebase, so we conservatively
+  // When opts.init is undefined we don't yet know hasFirebase, so we conservatively
   // require gcloud unless we know this is a Sentry-only init.
   const needsGcloud = opts.init !== "sentry";
   checkPrereqs(needsGcloud);
@@ -831,7 +831,7 @@ export async function run(opts: Options): Promise<void> {
       log("Key initialization complete.");
     } else {
       let oldFirebaseKeys: OldFirebaseKey[] = [];
-      let fp: FirebasePattern | null = null;
+      let fp: FirebasePattern | undefined;
       let oldSentryKeyId = "";
 
       if (hasFirebase) {

--- a/src/sync-env.ts
+++ b/src/sync-env.ts
@@ -18,7 +18,7 @@ interface Options {
   dryRun: boolean;
   rotateKeys: boolean;
   invalidateKeys: boolean;
-  init: "all" | "firebase" | "sentry" | null;
+  init?: "all" | "firebase" | "sentry";
 }
 
 const USAGE = `Usage: sync-env [OPTIONS]
@@ -102,7 +102,7 @@ export function parseArgs(argv: string[]): Options {
     dryRun: false,
     rotateKeys: false,
     invalidateKeys: true,
-    init: null,
+    init: undefined,
   };
   const args = argv.slice(2);
 


### PR DESCRIPTION
Per AGENTS.md: prefer `undefined` for absent optional values over `null`.

- `Options.init` in both `rotate-keys.ts` and `sync-env.ts` narrowed from `"all" | "firebase" | "sentry" | null` to `init?: "all" | "firebase" | "sentry"` (optional field)
- `fp` accumulator in `run()` changed from `FirebasePattern | null` to `FirebasePattern | undefined`
- `getFirebaseSaForEnv` return type changed from `FirebaseSaInfo | null` to `FirebaseSaInfo | undefined` (same pattern, same fix)
- All test callsites updated from `init: null` to `init: undefined`

Closes #39

---
*Created by Claude Sonnet 4.6*