### PR TITLE
feat: fall back to Vercel CLI auth token when VERCEL_TOKEN is unset

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveVercelToken } from "../lib/auth";
+
+describe("resolveVercelToken", () => {
+  let origEnv: NodeJS.ProcessEnv;
+  let tmpDir: string;
+  let authFile: string;
+
+  beforeEach(() => {
+    origEnv = { ...process.env };
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "auth-test-"));
+    authFile = path.join(tmpDir, "auth.json");
+    process.env.__VERCEL_CLI_AUTH_PATH = authFile;
+    delete process.env.VERCEL_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns VERCEL_TOKEN when set", () => {
+    process.env.VERCEL_TOKEN = "tok_from_env";
+    expect(resolveVercelToken()).toBe("tok_from_env");
+  });
+
+  it("reads token from CLI auth file when VERCEL_TOKEN is unset", () => {
+    fs.writeFileSync(
+      authFile,
+      JSON.stringify({
+        token: "tok_from_cli",
+        expiresAt: Date.now() / 1000 + 3600,
+      }),
+    );
+    expect(resolveVercelToken()).toBe("tok_from_cli");
+  });
+
+  it("prefers VERCEL_TOKEN over CLI auth file", () => {
+    process.env.VERCEL_TOKEN = "tok_from_env";
+    fs.writeFileSync(authFile, JSON.stringify({ token: "tok_from_cli" }));
+    expect(resolveVercelToken()).toBe("tok_from_env");
+  });
+
+  it("returns undefined when CLI token is expired", () => {
+    fs.writeFileSync(
+      authFile,
+      JSON.stringify({
+        token: "expired_tok",
+        expiresAt: Date.now() / 1000 - 1,
+      }),
+    );
+    expect(resolveVercelToken()).toBeUndefined();
+  });
+
+  it("returns undefined when CLI auth file is absent", () => {
+    // authFile was not written — does not exist
+    expect(resolveVercelToken()).toBeUndefined();
+  });
+
+  it("returns undefined when CLI auth file has no token field", () => {
+    fs.writeFileSync(authFile, JSON.stringify({ userId: "u123" }));
+    expect(resolveVercelToken()).toBeUndefined();
+  });
+
+  it("returns token when expiresAt is absent (non-expiring token)", () => {
+    fs.writeFileSync(authFile, JSON.stringify({ token: "permanent_tok" }));
+    expect(resolveVercelToken()).toBe("permanent_tok");
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -68,13 +68,3 @@ function readCliToken(): string | undefined {
 export function resolveVercelToken(): string | undefined {
   return process.env.VERCEL_TOKEN || readCliToken() || undefined;
 }
-
-/**
- * True if the token came from the CLI auth file rather than VERCEL_TOKEN.
- * Used to include a hint in error messages.
- */
-export function vercelTokenSource(): "env" | "cli" | "none" {
-  if (process.env.VERCEL_TOKEN) return "env";
-  if (readCliToken()) return "cli";
-  return "none";
-}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,80 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+interface VercelAuth {
+  token?: string;
+  expiresAt?: number;
+}
+
+function vercelCliAuthPath(): string {
+  if (process.env.__VERCEL_CLI_AUTH_PATH)
+    return process.env.__VERCEL_CLI_AUTH_PATH;
+  switch (process.platform) {
+    case "darwin":
+      return path.join(
+        os.homedir(),
+        "Library",
+        "Application Support",
+        "com.vercel.cli",
+        "auth.json",
+      );
+    case "win32":
+      return path.join(
+        process.env.APPDATA ?? os.homedir(),
+        "com.vercel.cli",
+        "auth.json",
+      );
+    default:
+      return path.join(
+        process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local", "share"),
+        "com.vercel.cli",
+        "auth.json",
+      );
+  }
+}
+
+function readCliToken(): string | undefined {
+  const authPath = vercelCliAuthPath();
+  let raw: string;
+  try {
+    raw = fs.readFileSync(authPath, "utf-8");
+  } catch {
+    return undefined;
+  }
+
+  let auth: VercelAuth;
+  try {
+    auth = JSON.parse(raw) as VercelAuth;
+  } catch {
+    return undefined;
+  }
+
+  if (!auth.token) return undefined;
+
+  if (auth.expiresAt !== undefined && Date.now() / 1000 > auth.expiresAt) {
+    return undefined;
+  }
+
+  return auth.token;
+}
+
+/**
+ * Returns the Vercel API token to use, preferring VERCEL_TOKEN env var and
+ * falling back to the token stored by the Vercel CLI (vercel login).
+ *
+ * Returns undefined if no token is available.
+ */
+export function resolveVercelToken(): string | undefined {
+  return process.env.VERCEL_TOKEN || readCliToken() || undefined;
+}
+
+/**
+ * True if the token came from the CLI auth file rather than VERCEL_TOKEN.
+ * Used to include a hint in error messages.
+ */
+export function vercelTokenSource(): "env" | "cli" | "none" {
+  if (process.env.VERCEL_TOKEN) return "env";
+  if (readCliToken()) return "cli";
+  return "none";
+}

--- a/src/lib/rotation.ts
+++ b/src/lib/rotation.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
+import { resolveVercelToken } from "./auth";
 import { err, log, warn } from "./logger";
 import { detectProject } from "./project";
 import { commandExists, run as runCmd } from "./subprocess";
@@ -40,8 +41,10 @@ function checkPrereqs(needsGcloud: boolean): void {
   if (needsGcloud && !commandExists("gcloud")) missing.push("gcloud");
   if (missing.length > 0) err(`Missing required tools: ${missing.join(" ")}`);
 
-  if (!process.env.VERCEL_TOKEN)
-    err("VERCEL_TOKEN environment variable is required");
+  if (!resolveVercelToken())
+    err(
+      "No Vercel token found. Set VERCEL_TOKEN or run 'vercel login' to authenticate.",
+    );
 
   try {
     runCmd("vercel", ["whoami"]);
@@ -65,7 +68,7 @@ export async function run(opts: RotationOptions): Promise<void> {
   );
 
   const client = new VercelClient(
-    process.env.VERCEL_TOKEN!,
+    resolveVercelToken()!,
     project.projectId,
     project.teamId,
   );

--- a/src/lib/rotation.ts
+++ b/src/lib/rotation.ts
@@ -35,13 +35,13 @@ export interface RotationOptions {
 
 // ─── Prerequisites ────────────────────────────────────────────────────────────
 
-function checkPrereqs(needsGcloud: boolean): void {
+function checkPrereqs(needsGcloud: boolean, token: string | undefined): void {
   const missing: string[] = [];
   if (!commandExists("vercel")) missing.push("vercel");
   if (needsGcloud && !commandExists("gcloud")) missing.push("gcloud");
   if (missing.length > 0) err(`Missing required tools: ${missing.join(" ")}`);
 
-  if (!resolveVercelToken())
+  if (!token)
     err(
       "No Vercel token found. Set VERCEL_TOKEN or run 'vercel login' to authenticate.",
     );
@@ -60,18 +60,15 @@ export async function run(opts: RotationOptions): Promise<void> {
   // When opts.init is undefined we don't yet know hasFirebase, so we conservatively
   // require gcloud unless we know this is a Sentry-only init.
   const needsGcloud = opts.init !== "sentry";
-  checkPrereqs(needsGcloud);
+  const token = resolveVercelToken();
+  checkPrereqs(needsGcloud, token);
 
   const project = detectProject();
   log(
     `Project: ${project.projectId}${project.teamId ? ` (team: ${project.teamId})` : ""}`,
   );
 
-  const client = new VercelClient(
-    resolveVercelToken()!,
-    project.projectId,
-    project.teamId,
-  );
+  const client = new VercelClient(token!, project.projectId, project.teamId);
 
   const allEnvs = await client.listEnvVars();
   const envKeys = allEnvs.envs.map((e) => e.key);

--- a/src/sync-env.ts
+++ b/src/sync-env.ts
@@ -7,6 +7,7 @@ import {
   parseDeploymentEnv,
   vercelTarget,
 } from "./lib/environments";
+import { resolveVercelToken } from "./lib/auth";
 import { FatalError, err, log, warn } from "./lib/logger";
 import { detectProject } from "./lib/project";
 import { run as rotateKeysRun } from "./lib/rotation";
@@ -47,8 +48,10 @@ OPTIONS:
   --dry-run                Print what would change without making any API calls
   -h, --help               Show this help
 
-REQUIRED ENVIRONMENT VARIABLES:
-  VERCEL_TOKEN       Vercel API token with project read/write access
+AUTHENTICATION (one of):
+  VERCEL_TOKEN       Vercel API token (takes precedence when set)
+  vercel login       Token is read automatically from the Vercel CLI auth file
+                     when VERCEL_TOKEN is not set
 
 OPTIONAL ENVIRONMENT VARIABLES:
   VERCEL_PROJECT_ID  Vercel project ID (auto-detected from .vercel/project.json)
@@ -201,8 +204,10 @@ function validateInitConfig(opts: Options, envList: string[]): void {
 }
 
 function checkPrereqs(opts: Options): void {
-  if (!process.env.VERCEL_TOKEN)
-    err("VERCEL_TOKEN environment variable is required");
+  if (!resolveVercelToken())
+    err(
+      "No Vercel token found. Set VERCEL_TOKEN or run 'vercel login' to authenticate.",
+    );
   if (!fs.existsSync(opts.deploymentDir))
     err(`Deployment directory not found: ${opts.deploymentDir}`);
   const envsFile = path.join(opts.deploymentDir, "environments.yml");
@@ -268,7 +273,7 @@ export async function run(opts: Options): Promise<void> {
   }
 
   const client = new VercelClient(
-    process.env.VERCEL_TOKEN!,
+    resolveVercelToken()!,
     project.projectId,
     project.teamId,
   );

--- a/src/sync-env.ts
+++ b/src/sync-env.ts
@@ -203,8 +203,8 @@ function validateInitConfig(opts: Options, envList: string[]): void {
     );
 }
 
-function checkPrereqs(opts: Options): void {
-  if (!resolveVercelToken())
+function checkPrereqs(opts: Options, token: string | undefined): void {
+  if (!token)
     err(
       "No Vercel token found. Set VERCEL_TOKEN or run 'vercel login' to authenticate.",
     );
@@ -215,7 +215,8 @@ function checkPrereqs(opts: Options): void {
 }
 
 export async function run(opts: Options): Promise<void> {
-  checkPrereqs(opts);
+  const token = resolveVercelToken();
+  checkPrereqs(opts, token);
 
   const project = detectProject();
   log(
@@ -272,11 +273,7 @@ export async function run(opts: Options): Promise<void> {
     return;
   }
 
-  const client = new VercelClient(
-    resolveVercelToken()!,
-    project.projectId,
-    project.teamId,
-  );
+  const client = new VercelClient(token!, project.projectId, project.teamId);
 
   let allEnvs = await client.listEnvVars();
   let totalCreated = 0;


### PR DESCRIPTION
Eliminates the friction of having to manually export `VERCEL_TOKEN` during development sessions. The Vercel CLI stores a session token in a platform-specific `auth.json` file that is automatically refreshed on each `vercel` invocation; `sync-env` and `rotate-keys` can read that token directly.

## What changed

Added `resolveVercelToken()` in `src/lib/auth.ts`. Both `sync-env` and `rotate-keys` now call it instead of reading `process.env.VERCEL_TOKEN` directly. `VERCEL_TOKEN` still takes precedence when set, so existing CI/CD setups are unaffected.

Tokens with an `expiresAt` timestamp in the past are ignored — the tool falls through to a clear "run `vercel login`" error rather than producing a confusing 401.

Supported auth file locations:
- **macOS**: `~/Library/Application Support/com.vercel.cli/auth.json`
- **Linux**: `$XDG_DATA_HOME/com.vercel.cli/auth.json` (defaults to `~/.local/share/…`)
- **Windows**: `%APPDATA%\com.vercel.cli\auth.json`

---
*Created by Claude Sonnet 4.6*