### PR TITLE
feat: auto-detect what to initialize when --init is passed without a service argument

### DIFF
--- a/src/__tests__/sync-env-tests/parse-args.test.ts
+++ b/src/__tests__/sync-env-tests/parse-args.test.ts
@@ -54,9 +54,9 @@ describe("parseArgs", () => {
     expect(opts.invalidateKeys).toBe(true);
   });
 
-  it("--init alone sets init to all and implies rotateKeys", () => {
+  it("--init alone sets init to auto and implies rotateKeys", () => {
     const opts = parseArgs(["node", "sync-env", "--init"]);
-    expect(opts.init).toBe("all");
+    expect(opts.init).toBe("auto");
     expect(opts.rotateKeys).toBe(true);
   });
 
@@ -80,7 +80,7 @@ describe("parseArgs", () => {
       "--env",
       "production",
     ]);
-    expect(opts.init).toBe("all");
+    expect(opts.init).toBe("auto");
     expect(opts.targetEnv).toBe("production");
   });
 

--- a/src/__tests__/sync-env-tests/run-rotate.test.ts
+++ b/src/__tests__/sync-env-tests/run-rotate.test.ts
@@ -703,6 +703,69 @@ describe("run", () => {
     );
   });
 
+  it("--init auto --env staging ignores production-only secrets when detecting for staging", async () => {
+    const rotateKeys = await import("../../lib/rotation");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "1",
+          key: "FIREBASE_SERVICE_ACCOUNT",
+          value: "{}",
+          target: ["production"],
+          type: "encrypted",
+        },
+        {
+          id: "2",
+          key: "FIREBASE_PROJECT_ID",
+          value: "my-staging-proj",
+          target: ["preview"],
+          type: "plain",
+        },
+        {
+          id: "3",
+          key: "FIREBASE_SA_EMAIL",
+          value: "sa@staging.iam.gserviceaccount.com",
+          target: ["preview"],
+          type: "plain",
+        },
+      ],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["staging"], {
+      staging: {
+        MY_KEY: "val",
+        FIREBASE_SA_EMAIL: "sa@staging.iam.gserviceaccount.com",
+        FIREBASE_PROJECT_ID: "my-staging-proj",
+      },
+    });
+    await run({
+      targetEnv: "staging",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "auto",
+    });
+
+    expect(mockRotate).toHaveBeenCalledWith(
+      expect.objectContaining({ init: "firebase" }),
+    );
+  });
+
   it("accepts shell env as fallback for missing YAML firebase vars", async () => {
     process.env.FIREBASE_SA_EMAIL = "sa@fallback.iam.gserviceaccount.com";
     process.env.GCLOUD_PROJECT = "fallback-project";

--- a/src/__tests__/sync-env-tests/run-rotate.test.ts
+++ b/src/__tests__/sync-env-tests/run-rotate.test.ts
@@ -401,6 +401,308 @@ describe("run", () => {
     );
   });
 
+  // ─── --init auto detection ────────────────────────────────────────────────────
+
+  it("--init auto detects Firebase when public vars present and no secrets", async () => {
+    const rotateKeys = await import("../../lib/rotation");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "1",
+          key: "FIREBASE_PROJECT_ID",
+          value: "my-proj",
+          target: ["production"],
+          type: "plain",
+        },
+        {
+          id: "2",
+          key: "FIREBASE_SA_EMAIL",
+          value: "sa@my-proj.iam.gserviceaccount.com",
+          target: ["production"],
+          type: "plain",
+        },
+      ],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["production"], {
+      production: {
+        MY_KEY: "val",
+        FIREBASE_SA_EMAIL: "sa@my-proj.iam.gserviceaccount.com",
+        FIREBASE_PROJECT_ID: "my-proj",
+      },
+    });
+    await run({
+      targetEnv: "all",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "auto",
+    });
+
+    expect(mockRotate).toHaveBeenCalledWith(
+      expect.objectContaining({ init: "firebase" }),
+    );
+    expect(mockRotate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ init: "sentry" }),
+    );
+  });
+
+  it("--init auto detects Sentry when public vars present and no secrets", async () => {
+    const rotateKeys = await import("../../lib/rotation");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "1",
+          key: "SENTRY_ORG",
+          value: "my-org",
+          target: ["production"],
+          type: "plain",
+        },
+        {
+          id: "2",
+          key: "SENTRY_PROJECT",
+          value: "my-proj",
+          target: ["production"],
+          type: "plain",
+        },
+      ],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["production"], {
+      production: {
+        MY_KEY: "val",
+        SENTRY_ORG: "my-org",
+        SENTRY_PROJECT: "my-proj",
+      },
+    });
+    await run({
+      targetEnv: "all",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "auto",
+    });
+
+    expect(mockRotate).toHaveBeenCalledWith(
+      expect.objectContaining({ init: "sentry" }),
+    );
+    expect(mockRotate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ init: "firebase" }),
+    );
+  });
+
+  it("--init auto detects both when both public vars present and no secrets", async () => {
+    const rotateKeys = await import("../../lib/rotation");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "1",
+          key: "FIREBASE_PROJECT_ID",
+          value: "my-proj",
+          target: ["production"],
+          type: "plain",
+        },
+        {
+          id: "2",
+          key: "FIREBASE_SA_EMAIL",
+          value: "sa@my-proj.iam.gserviceaccount.com",
+          target: ["production"],
+          type: "plain",
+        },
+        {
+          id: "3",
+          key: "SENTRY_ORG",
+          value: "my-org",
+          target: ["production"],
+          type: "plain",
+        },
+        {
+          id: "4",
+          key: "SENTRY_PROJECT",
+          value: "my-sentry-proj",
+          target: ["production"],
+          type: "plain",
+        },
+      ],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["production"], {
+      production: {
+        MY_KEY: "val",
+        FIREBASE_SA_EMAIL: "sa@my-proj.iam.gserviceaccount.com",
+        FIREBASE_PROJECT_ID: "my-proj",
+        SENTRY_ORG: "my-org",
+        SENTRY_PROJECT: "my-sentry-proj",
+      },
+    });
+    await run({
+      targetEnv: "all",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "auto",
+    });
+
+    expect(mockRotate).toHaveBeenCalledWith(
+      expect.objectContaining({ init: "sentry" }),
+    );
+    expect(mockRotate).toHaveBeenCalledWith(
+      expect.objectContaining({ init: "firebase" }),
+    );
+  });
+
+  it("--init auto errors when no public vars present", async () => {
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "1",
+          key: "SOME_OTHER_VAR",
+          value: "val",
+          target: ["production"],
+          type: "plain",
+        },
+      ],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["production"], {
+      production: { MY_KEY: "val" },
+    });
+
+    await expect(
+      run({
+        targetEnv: "all",
+        deploymentDir: deployDir,
+        dryRun: false,
+        rotateKeys: true,
+        invalidateKeys: true,
+        init: "auto",
+      }),
+    ).rejects.toThrow(/nothing to initialize/);
+  });
+
+  it("--init auto skips Firebase when secrets already exist", async () => {
+    const rotateKeys = await import("../../lib/rotation");
+    const mockRotate = vi.spyOn(rotateKeys, "run").mockResolvedValue(undefined);
+
+    const { VercelClient } = await import("../../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "1",
+          key: "FIREBASE_SERVICE_ACCOUNT",
+          value: "{}",
+          target: ["production"],
+          type: "encrypted",
+        },
+        {
+          id: "2",
+          key: "SENTRY_ORG",
+          value: "my-org",
+          target: ["production"],
+          type: "plain",
+        },
+        {
+          id: "3",
+          key: "SENTRY_PROJECT",
+          value: "my-proj",
+          target: ["production"],
+          type: "plain",
+        },
+      ],
+      pagination: undefined,
+    });
+    vi.spyOn(VercelClient.prototype, "findEnvVar").mockReturnValue(undefined);
+    vi.spyOn(VercelClient.prototype, "createEnvVar").mockResolvedValue({
+      id: "x",
+      key: "k",
+      value: "v",
+      target: [],
+      type: "plain",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const deployDir = makeDeploymentDir(tmpDir, ["production"], {
+      production: {
+        MY_KEY: "val",
+        SENTRY_ORG: "my-org",
+        SENTRY_PROJECT: "my-proj",
+      },
+    });
+    await run({
+      targetEnv: "all",
+      deploymentDir: deployDir,
+      dryRun: false,
+      rotateKeys: true,
+      invalidateKeys: true,
+      init: "auto",
+    });
+
+    expect(mockRotate).toHaveBeenCalledWith(
+      expect.objectContaining({ init: "sentry" }),
+    );
+    expect(mockRotate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ init: "firebase" }),
+    );
+  });
+
   it("accepts shell env as fallback for missing YAML firebase vars", async () => {
     process.env.FIREBASE_SA_EMAIL = "sa@fallback.iam.gserviceaccount.com";
     process.env.GCLOUD_PROJECT = "fallback-project";

--- a/src/sync-env.ts
+++ b/src/sync-env.ts
@@ -11,7 +11,7 @@ import { resolveVercelToken } from "./lib/auth";
 import { FatalError, err, log, warn } from "./lib/logger";
 import { detectProject } from "./lib/project";
 import { run as rotateKeysRun } from "./lib/rotation";
-import { VercelClient } from "./lib/vercel-api";
+import { VercelClient, VercelEnvVar } from "./lib/vercel-api";
 
 interface Options {
   targetEnv: string;
@@ -206,21 +206,31 @@ function validateInitConfig(opts: Options, envList: string[]): void {
     );
 }
 
-function resolveAutoInit(envKeys: string[]): "all" | "firebase" | "sentry" {
-  const hasFirebaseSecrets = envKeys.some((k) =>
+function resolveAutoInit(
+  envVars: VercelEnvVar[],
+  targetEnv: string,
+): "all" | "firebase" | "sentry" {
+  const relevantTargets =
+    targetEnv === "all" ? ["production", "preview"] : [vercelTarget(targetEnv)];
+  const scoped = envVars.filter((e) =>
+    e.target.some((t) => relevantTargets.includes(t)),
+  );
+  const keys = scoped.map((e) => e.key);
+
+  const hasFirebaseSecrets = keys.some((k) =>
     ["FIREBASE_SERVICE_ACCOUNT", "FIREBASE_PRIVATE_KEY"].includes(k),
   );
-  const hasFirebasePublic = envKeys.some((k) =>
+  const hasFirebasePublic = keys.some((k) =>
     [
       "FIREBASE_PROJECT_ID",
       "FIREBASE_SA_EMAIL",
       "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
     ].includes(k),
   );
-  const hasSentrySecrets = envKeys.some((k) =>
+  const hasSentrySecrets = keys.some((k) =>
     ["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"].includes(k),
   );
-  const hasSentryPublic = envKeys.some((k) =>
+  const hasSentryPublic = keys.some((k) =>
     ["SENTRY_ORG", "SENTRY_PROJECT"].includes(k),
   );
 
@@ -328,7 +338,7 @@ export async function run(opts: Options): Promise<void> {
   let allEnvs = await client.listEnvVars();
 
   if (opts.init === "auto") {
-    opts.init = resolveAutoInit(allEnvs.envs.map((e) => e.key));
+    opts.init = resolveAutoInit(allEnvs.envs, opts.targetEnv);
     validateInitConfig(opts, envList);
   }
 

--- a/src/sync-env.ts
+++ b/src/sync-env.ts
@@ -19,7 +19,7 @@ interface Options {
   dryRun: boolean;
   rotateKeys: boolean;
   invalidateKeys: boolean;
-  init?: "all" | "firebase" | "sentry";
+  init?: "all" | "auto" | "firebase" | "sentry";
 }
 
 const USAGE = `Usage: sync-env [OPTIONS]
@@ -41,8 +41,11 @@ OPTIONS:
   --deployment-dir <path>  Path to deployment config directory (default: deployment/)
   --rotate-keys            Also rotate Firebase/Sentry secrets and redeploy
   --init [firebase|sentry] Bootstrap initial secrets for a fresh project (implies
-                           --rotate-keys). Accepts firebase, sentry, or omit for
-                           both. Fails if the chosen secrets already exist.
+                           --rotate-keys). Accepts firebase or sentry to target a
+                           specific service. Omit to auto-detect: initializes only
+                           the services that are missing secrets but have public
+                           config vars present. Fails if the target secrets already
+                           exist.
   --no-invalidate          (with --rotate-keys) Skip deleting old keys after
                            redeployment
   --dry-run                Print what would change without making any API calls
@@ -137,7 +140,7 @@ export function parseArgs(argv: string[]): Options {
         opts.init = next;
         i++;
       } else {
-        opts.init = "all";
+        opts.init = "auto";
       }
       opts.rotateKeys = true;
     } else if (arg === "--no-invalidate") {
@@ -203,6 +206,51 @@ function validateInitConfig(opts: Options, envList: string[]): void {
     );
 }
 
+function resolveAutoInit(envKeys: string[]): "all" | "firebase" | "sentry" {
+  const hasFirebaseSecrets = envKeys.some((k) =>
+    ["FIREBASE_SERVICE_ACCOUNT", "FIREBASE_PRIVATE_KEY"].includes(k),
+  );
+  const hasFirebasePublic = envKeys.some((k) =>
+    [
+      "FIREBASE_PROJECT_ID",
+      "FIREBASE_SA_EMAIL",
+      "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+    ].includes(k),
+  );
+  const hasSentrySecrets = envKeys.some((k) =>
+    ["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"].includes(k),
+  );
+  const hasSentryPublic = envKeys.some((k) =>
+    ["SENTRY_ORG", "SENTRY_PROJECT"].includes(k),
+  );
+
+  const initFirebase = !hasFirebaseSecrets && hasFirebasePublic;
+  const initSentry = !hasSentrySecrets && hasSentryPublic;
+
+  log("Auto-detecting --init:");
+  if (initFirebase)
+    log(
+      "  Firebase: initialize (no service account found, Firebase public vars present)",
+    );
+  else if (hasFirebaseSecrets)
+    log("  Firebase: skip (service account already configured)");
+  else log("  Firebase: skip (no Firebase public vars configured)");
+
+  if (initSentry)
+    log("  Sentry: initialize (no DSN found, Sentry public vars present)");
+  else if (hasSentrySecrets) log("  Sentry: skip (DSN already configured)");
+  else log("  Sentry: skip (no Sentry public vars configured)");
+
+  if (!initFirebase && !initSentry)
+    err(
+      "--init: nothing to initialize — Firebase and Sentry are either already configured or have no public config vars present in this project",
+    );
+
+  if (initFirebase && initSentry) return "all";
+  if (initFirebase) return "firebase";
+  return "sentry";
+}
+
 function checkPrereqs(opts: Options, token: string | undefined): void {
   if (!token)
     err(
@@ -241,7 +289,7 @@ export async function run(opts: Options): Promise<void> {
     envList = [opts.targetEnv];
   }
 
-  if (opts.init) validateInitConfig(opts, envList);
+  if (opts.init && opts.init !== "auto") validateInitConfig(opts, envList);
 
   if (opts.dryRun) {
     log("Dry run — no changes will be made");
@@ -266,9 +314,11 @@ export async function run(opts: Options): Promise<void> {
     }
     if (opts.rotateKeys)
       log(
-        opts.init
-          ? "Would init secrets (skipped in dry-run)"
-          : "Would rotate keys (skipped in dry-run)",
+        opts.init === "auto"
+          ? "Would auto-detect and initialize missing secrets (skipped in dry-run — requires Vercel API)"
+          : opts.init
+            ? "Would init secrets (skipped in dry-run)"
+            : "Would rotate keys (skipped in dry-run)",
       );
     return;
   }
@@ -276,6 +326,12 @@ export async function run(opts: Options): Promise<void> {
   const client = new VercelClient(token!, project.projectId, project.teamId);
 
   let allEnvs = await client.listEnvVars();
+
+  if (opts.init === "auto") {
+    opts.init = resolveAutoInit(allEnvs.envs.map((e) => e.key));
+    validateInitConfig(opts, envList);
+  }
+
   let totalCreated = 0;
   let totalUpdated = 0;
 


### PR DESCRIPTION
Previously, `--init` without an argument always initialized both Firebase and Sentry, failing if either was already configured. This made `--init` non-idempotent and required users to know ahead of time which services needed bootstrapping.

`--init` now auto-detects what to initialize by inspecting the existing Vercel project's public env vars:

- **Firebase**: initialize if `FIREBASE_SERVICE_ACCOUNT` / `FIREBASE_PRIVATE_KEY` are absent **and** at least one of `FIREBASE_PROJECT_ID`, `FIREBASE_SA_EMAIL`, or `NEXT_PUBLIC_FIREBASE_PROJECT_ID` is present
- **Sentry**: initialize if `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` are absent **and** `SENTRY_ORG` or `SENTRY_PROJECT` is present

Detection results are logged so the user knows what will and won't be initialized. If neither service is detected (no relevant public vars, or all secrets already exist), the command errors with a clear explanation. Explicit `--init firebase` and `--init sentry` are unchanged.

Closes #48

---
*Created by Claude Sonnet 4.6*