### PR TITLE
fix: scope --init key-existence check to the specific Vercel target

### DIFF
--- a/src/__tests__/rotation.test.ts
+++ b/src/__tests__/rotation.test.ts
@@ -182,6 +182,37 @@ describe("run — --init guard checks", () => {
     ).rejects.toThrow("already exist");
   });
 
+  it("does not block --init firebase for production when Firebase key exists only on preview", async () => {
+    await setupMocks();
+    process.env.FIREBASE_SA_EMAIL = "sa@my-project.iam.gserviceaccount.com";
+    process.env.GCLOUD_PROJECT = "my-project";
+    const { VercelClient } = await import("../lib/vercel-api");
+    vi.spyOn(VercelClient.prototype, "listEnvVars").mockResolvedValue({
+      envs: [
+        {
+          id: "e1",
+          key: "FIREBASE_SERVICE_ACCOUNT",
+          value: "{}",
+          target: ["preview"],
+          type: "encrypted",
+        },
+      ],
+      pagination: undefined,
+    });
+
+    // Guard passes — the preview-scoped key is invisible to the production check.
+    // The run ultimately fails deeper (gcloud mock writes no key file), but the
+    // error must not be the "already exist" guard.
+    const error = await run({
+      targetEnv: "production",
+      invalidateKeys: true,
+      init: "firebase",
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain("already exist");
+  });
+
   it("throws FatalError when --init firebase and FIREBASE_SA_EMAIL is not set", async () => {
     await setupMocks();
     delete process.env.FIREBASE_SA_EMAIL;

--- a/src/lib/rotation.ts
+++ b/src/lib/rotation.ts
@@ -71,7 +71,14 @@ export async function run(opts: RotationOptions): Promise<void> {
   const client = new VercelClient(token!, project.projectId, project.teamId);
 
   const allEnvs = await client.listEnvVars();
-  const envKeys = allEnvs.envs.map((e) => e.key);
+  // Scope key-existence checks to the specific Vercel target so that
+  // successive per-env --init calls (e.g. preview then production) don't
+  // see secrets created for an earlier target and falsely error.
+  const scopedEnvs =
+    opts.targetEnv === "all"
+      ? allEnvs.envs
+      : allEnvs.envs.filter((e) => e.target.includes(opts.targetEnv));
+  const envKeys = scopedEnvs.map((e) => e.key);
 
   const hasFirebase = envKeys.some((k) =>
     ["FIREBASE_SERVICE_ACCOUNT", "FIREBASE_PRIVATE_KEY"].includes(k),


### PR DESCRIPTION
When `--init firebase` is run with `--env all`, `sync-env` calls `rotateKeysRun` once per deployment environment (production, preview). After the first call created `FIREBASE_SERVICE_ACCOUNT` for the preview target, the second call fetched all project env vars project-wide and found the key present — erroring "Firebase keys already exist" even though the production target had never been initialized.

The `hasFirebase` / `hasSentry` check in `rotation.ts` now filters `allEnvs.envs` to only vars whose `target` array includes `opts.targetEnv` before checking for key presence. For `targetEnv === "all"` the full list is used unchanged, preserving existing behaviour for rotation and single-call init flows.

---
*Created by Claude Sonnet 4.6*