### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -11,6 +11,7 @@ jobs:
   pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - name: Check PR title format
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   bats:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -19,6 +20,7 @@ jobs:
 
   vitest:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -31,6 +33,7 @@ jobs:
 
   gitleaks-fixtures:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
       - name: Install gitleaks
@@ -48,6 +51,7 @@ jobs:
 
   yaml-parsing:
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4
       - run: bash tests/terraform/test-yaml-parsing.sh


### PR DESCRIPTION
## Summary

Adds explicit `timeout-minutes` to every job across `pr-title-lint.yml`, `release.yml`, `secret-scan.yml`, and `test.yml`. GitHub Actions' default job timeout is 360 minutes (6 hours), which is far too high to catch stuck or runaway jobs in a useful window.

Values were sized at roughly 3× the observed worst case over the last ~15 runs of each workflow, then floored at 1 minute:

| Job | Worst observed | `timeout-minutes` |
| --- | --- | --- |
| `Validate PR title` | 4s | 1 |
| `yaml-parsing` | 6s | 1 |
| `gitleaks-fixtures` | 9s | 2 |
| `bats` | 18s | 3 |
| `vitest` | 22s | 3 |
| `release` | 29s | 5 |
| Reusable `gitleaks` (Secret Scan) | n/a here (~45s reported externally) | 3 |

## Technical notes

- `release` gets 5m rather than the formulaic ~2m to leave headroom for semantic-release retries on transient npm/GitHub failures.
- `secret-scan.yml` is a reusable `workflow_call` with no callers in this repo, so timing data was inferred from the user's external observation (~45s typical, 3m suggested ceiling) for the upstream `gitleaks-action`.

---
*Created by Claude Opus 4.7*