### PR TITLE
chore: mark pnpm-lock.yaml as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pnpm-lock.yaml linguist-generated=true


### PR DESCRIPTION
Adds `.gitattributes` so GitHub treats `pnpm-lock.yaml` as a generated file — it's excluded from language statistics and collapsed by default in PR diffs.

This repo has no lint-staged setup, so the lockfile-exclusion filter from lint-staged config (as in [firebase-nextjs-template#90](https://github.com/rmartz/firebase-nextjs-template/pull/90)) doesn't apply here.

---
*Created by Claude Sonnet 4.6*