### PR TITLE
chore: add .git-worktrees/ to .gitignore and .prettierignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 .env.local
 .env.*.local
+.git-worktrees/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 CHANGELOG.md
 .claude/
+.git-worktrees/


### PR DESCRIPTION
Excludes the `.git-worktrees/` directory from git tracking and Prettier formatting. These worktrees are ephemeral agent workspaces and should never be committed or formatted.

`.eslintignore` was also present in the root worktree but is intentionally excluded here — [#61](https://github.com/rmartz/vercel-deploy-scripts/pull/61) migrates to ESLint flat config and already includes `.git-worktrees/**` in `eslint.config.mjs`'s `ignores` array, so adding `.eslintignore` would be redundant and would conflict on merge.

---
*Created by Claude Sonnet 4.6*