### PR TITLE
chore: add Dependabot config with a 7-day update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot version updates.
+#
+# A 7-day cooldown is applied to every ecosystem: Dependabot will not open an
+# update PR until the new release is at least 7 days old. This reduces exposure
+# to supply-chain attacks where a compromised package version is published and
+# typically caught and yanked within a few days of release.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds `.github/dependabot.yml` (none existed) with a **7-day cooldown** on every ecosystem, so Dependabot waits until a release is at least a week old before opening an update PR. This narrows the window in which a freshly-published compromised version could be pulled in before it is detected and yanked — the standard supply-chain mitigation.

## Details

- **Ecosystems**: `npm` (pnpm dependencies) and `github-actions` (workflow action pins) — both are real supply-chain surfaces, so both get the cooldown.
- **`cooldown.default-days: 7`** applies to all update types (major/minor/patch).
- **Schedule** is `weekly`; the cooldown is the explicit 7-day delay, the schedule is just the check cadence.

Since there was no prior config, this also turns on Dependabot **version updates** for the first time (security updates run independently of this file). If you'd rather scope it to npm only, drop the `github-actions` block.

---
*Created by Claude Opus 4.8*