### PR TITLE
chore: group Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@
 # update PR until the new release is at least 7 days old. This reduces exposure
 # to supply-chain attacks where a compromised package version is published and
 # typically caught and yanked within a few days of release.
+#
+# Updates are grouped to cut PR volume: routine minor and patch bumps are
+# batched into a single PR per ecosystem, while major version bumps stay
+# ungrouped so each gets its own PR for isolated review.
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -12,6 +16,13 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,3 +30,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,10 @@
 # to supply-chain attacks where a compromised package version is published and
 # typically caught and yanked within a few days of release.
 #
-# Updates are grouped to cut PR volume: routine minor and patch bumps are
-# batched into a single PR per ecosystem, while major version bumps stay
-# ungrouped so each gets its own PR for isolated review.
+# Updates are grouped to cut PR volume:
+#   - npm: production and development dependencies are batched into one PR each,
+#     split so a runtime-dependency change is never bundled with tooling churn.
+#   - github-actions: a single group batches all action bumps into one PR.
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -17,12 +18,10 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      npm-minor-and-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+      npm-production:
+        dependency-type: "production"
+      npm-development:
+        dependency-type: "development"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -31,9 +30,6 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      github-actions-minor-and-patch:
+      github-actions:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,9 @@
 #
 # Updates are grouped to cut PR volume:
 #   - npm: production and development dependencies are batched into one PR each,
-#     split so a runtime-dependency change is never bundled with tooling churn.
+#     restricted to minor and patch bumps so a runtime-dependency change is never
+#     bundled with tooling churn. Major bumps match no group and so are raised as
+#     individual PRs for isolated review.
 #   - github-actions: a single group batches all action bumps into one PR.
 version: 2
 updates:
@@ -20,8 +22,14 @@ updates:
     groups:
       npm-production:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       npm-development:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Adds a `groups` block to each ecosystem in `.github/dependabot.yml` so routine updates arrive batched instead of one-PR-per-dependency.

## Grouping

- **npm** — two groups keyed on `dependency-type`, each restricted to minor/patch:
  - `npm-production` — `dependencies`, minor + patch bumps → one PR.
  - `npm-development` — `devDependencies`, minor + patch bumps → one PR.
  - **Major bumps match no group**, so each is raised as its own PR for isolated review.

  This combines the prod/dev split (a runtime-dependency change is never bundled with tooling churn) with per-major scrutiny.
- **github-actions** — a single `github-actions` group (`patterns: ["*"]`) batches **all** action bumps, majors included, into one PR.

Composes with the existing 7-day cooldown: a grouped PR only includes updates that have already cleared cooldown.

---
*Created by Claude Opus 4.8*